### PR TITLE
Update license headers to reassign copyright

### DIFF
--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/remove.go
+++ b/cmd/krew/cmd/remove.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/krew/main.go
+++ b/cmd/krew/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/download/fetch.go
+++ b/pkg/download/fetch.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/download/fetch_test.go
+++ b/pkg/download/fetch_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/download/verifier.go
+++ b/pkg/download/verifier.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/download/verifier_test.go
+++ b/pkg/download/verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/gitutil/git.go
+++ b/pkg/gitutil/git.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/scanner.go
+++ b/pkg/index/indexscanner/scanner.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/scanner_test.go
+++ b/pkg/index/indexscanner/scanner_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/testdata/testindex/dontscan.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/dontscan.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/testdata/testindex/plugins/badplugin.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/badplugin.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/testdata/testindex/plugins/badplugin2.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/badplugin2.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/index/indexscanner/testdata/testindex/plugins/wrongname.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/wrongname.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/index/types.go
+++ b/pkg/index/types.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/install_test.go
+++ b/pkg/installation/install_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/move_test.go
+++ b/pkg/installation/move_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/testdata/index/foo/deadbeef/kubectl-foo
+++ b/pkg/installation/testdata/index/foo/deadbeef/kubectl-foo
@@ -1,4 +1,4 @@
-# Copyright © 2018 Google Inc.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/installation/upgrade.go
+++ b/pkg/installation/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/util.go
+++ b/pkg/installation/util.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/installation/util_test.go
+++ b/pkg/installation/util_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/pathutil/pathutil.go
+++ b/pkg/pathutil/pathutil.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/pathutil/pathutil_test.go
+++ b/pkg/pathutil/pathutil_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Google Inc.
+// Copyright 2019 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reference: https://github.com/kubernetes/community/pull/3427

Updating the source code copyright per the https://github.com/kubernetes/org/issues/599
as someone from the Google organization which has donated the krew code.

/assign @nikhita 