### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Read the [User Guide](./docs/USER_GUIDE.md) for detailed documentation.
 
 ### Installation
 
-> :warning: **Warning:** krew is only compatible with kubectl v1.12 or higher.
+> :warning: **Warning:** krew is only compatible with kubectl v1.12 or higher.  
+> :warning: **Warning:** check your bash version krew is compatible with bash v4.0 or higher 
+(for osx, install the latest bash with ```brew install bash```)
 
 **macOS and Linux:**
 


### PR DESCRIPTION
I have some trouble with OSX 10.14.4 because there is bash 3.x by default and has not built in command mapfile. https://github.com/bminor/bash/blob/bash-4.0/CHANGES#L573
I repaired it with `brew install bash` :)