### PR TITLE
Add CLI for setting Windows path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ Read the [User Guide](./docs/USER_GUIDE.md) for detailed documentation.
        .\krew-windows_amd64.exe install --manifest=krew.yaml --archive=krew.zip
 
 1. Add `%USERPROFILE%\.krew\bin` to your `PATH` environment variable
-   ([how?](https://java.com/en/download/help/path.xml))
+
+    ```sh
+    setx PATH "%USERPROFILE%\.krew\bin;%PATH%"
+    ```
+
+  and restart your command prompt.
 
 [releases]: https://github.com/kubernetes-sigs/krew/releases
 


### PR DESCRIPTION
Use ```setx``` DOS commandline to set per-user %PATH% environment variable  - [Windows docs](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx)