### PR TITLE
Rename `krew remove` to `krew uninstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ similar to tools like apt, dnf or [brew](http://brew.sh).
 krew is easy to use:
 
 ```sh
-kubectl krew search               # show all plugins
-kubectl krew install view-secret  # install a plugin named "view-secret"
-kubectl view-secret               # use the plugin
-kubectl krew upgrade              # upgrade installed plugins
-kubectl krew remove view-secret   # uninstall a plugin
+kubectl krew search                 # show all plugins
+kubectl krew install view-secret    # install a plugin named "view-secret"
+kubectl view-secret                 # use the plugin
+kubectl krew upgrade                # upgrade installed plugins
+kubectl krew uninstall view-secret  # uninstall a plugin
 ```
 
 Read the [User Guide](./docs/USER_GUIDE.md) for detailed documentation.

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -25,31 +25,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// removeCmd represents the remove command
-var removeCmd = &cobra.Command{
-	Use:   "remove",
+// uninstallCmd represents the uninstall command
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
 	Short: "Uninstall plugins",
 	Long: `Uninstall one or more plugins.
 
 Example:
-  kubectl krew remove NAME [NAME...]
+  kubectl krew uninstall NAME [NAME...]
 
 Remarks:
   Failure to uninstall a plugin will result in an error and exit immediately.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, name := range args {
-			glog.V(4).Infof("Going to remove plugin %s\n", name)
-			if err := installation.Remove(paths, name); err != nil {
-				return errors.Wrapf(err, "failed to remove plugin %s", name)
+			glog.V(4).Infof("Going to uninstall plugin %s\n", name)
+			if err := installation.Uninstall(paths, name); err != nil {
+				return errors.Wrapf(err, "failed to uninstall plugin %s", name)
 			}
-			fmt.Fprintf(os.Stderr, "Removed plugin %s\n", name)
+			fmt.Fprintf(os.Stderr, "Uninstalled plugin %s\n", name)
 		}
 		return nil
 	},
 	PreRunE: checkIndex,
 	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"remove"},
 }
 
 func init() {
-	rootCmd.AddCommand(removeCmd)
+	rootCmd.AddCommand(uninstallCmd)
 }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -297,7 +297,7 @@ if you're on a Linux machine, you can test Windows installation with:
 
     KREW_OS=windows krew install --manifest=[...]
 
-After you have tested your plugin, remove it with `kubectl krew remove foo`.
+After you have tested your plugin, uninstall it with `kubectl krew uninstall foo`.
 
 ## Publishing Plugins
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -126,7 +126,7 @@ allows you to upgrade to the latest commit available in the source repository.
 
 When you don't need a plugin anymore you can uninstall it with:
 
-    kubectl krew remove <PLUGIN>
+    kubectl krew uninstall <PLUGIN>
 
 ## Uninstalling Krew
 

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -106,15 +106,15 @@ func install(plugin, version, uri, bin string, p environment.Paths, fos []index.
 	return createOrUpdateLink(p.BinPath(), filepath.Join(dst, filepath.FromSlash(bin)), plugin)
 }
 
-// Remove will remove a plugin.
-func Remove(p environment.Paths, name string) error {
+// Uninstall will uninstall a plugin.
+func Uninstall(p environment.Paths, name string) error {
 	if name == krewPluginName {
 		return errors.Errorf("removing krew is not allowed through krew. Please run:\n\t rm -r %s", p.BasePath())
 	}
 	glog.V(3).Infof("Finding installed version to delete")
 	version, installed, err := findInstalledPluginVersion(p.InstallPath(), p.BinPath(), name)
 	if err != nil {
-		return errors.Wrap(err, "can't remove plugin")
+		return errors.Wrap(err, "can't uninstall plugin")
 	}
 	if !installed {
 		return ErrIsNotInstalled

--- a/pkg/installation/install_test.go
+++ b/pkg/installation/install_test.go
@@ -153,11 +153,11 @@ func Test_removeLink_notExists(t *testing.T) {
 	}
 }
 
-func TestRemove_cantUninstallItself(t *testing.T) {
+func TestUninstall_cantUninstallItself(t *testing.T) {
 	envPath := environment.MustGetKrewPaths()
 	expectedErrorMessagePart := "not allowed"
-	if err := Remove(envPath, "krew"); !strings.Contains(err.Error(), expectedErrorMessagePart) {
-		t.Fatalf("wrong error message for 'remove krew' action, expected message contains %q; got %q",
+	if err := Uninstall(envPath, "krew"); !strings.Contains(err.Error(), expectedErrorMessagePart) {
+		t.Fatalf("wrong error message for 'uninstall krew' action, expected message contains %q; got %q",
 			expectedErrorMessagePart, err.Error())
 	}
 }


### PR DESCRIPTION
The inverse of `install` is `uninstall`, so this PR renames `krew remove`
to `krew uninstall`, and makes `krew remove` an alias to `krew uninstall`.

/close #188 