### PR TITLE
Validate manifest file extension and kind field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
 before_install:
 - go get github.com/mitchellh/gox
 script:
+- hack/check-code-patterns.sh
 - hack/verify-boilerplate.sh
 - hack/gofmt.sh
 - hack/run_lint.sh

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -61,7 +62,11 @@ func validateManifestFile(path string) error {
 		return errors.Wrap(err, "failed to read plugin file")
 	}
 	filename := filepath.Base(path)
-	pluginNameFromFileName := strings.TrimSuffix(filename, filepath.Ext(filename))
+	manifestExtension := filepath.Ext(filename)
+	if manifestExtension != ".yaml" {
+		return fmt.Errorf("expected manifest extension '.yaml' but found '%s'", manifestExtension)
+	}
+	pluginNameFromFileName := strings.TrimSuffix(filename, manifestExtension)
 	glog.V(4).Infof("inferred plugin name as %s", pluginNameFromFileName)
 
 	// validate plugin manifest

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -82,7 +82,7 @@ func TestValidateManifestFile(t *testing.T) {
 					ShortDescription: "test",
 					Platforms: []index.Platform{{
 						Head:  "http://test.com",
-						Files: []index.FileOperation{{"", ""}},
+						Files: []index.FileOperation{{From: "", To: ""}},
 						Bin:   "bin",
 						Selector: &v1.LabelSelector{
 							MatchLabels: map[string]string{"os": "darwin", "arch": "arm"},
@@ -109,14 +109,14 @@ func TestValidateManifestFile(t *testing.T) {
 					Platforms: []index.Platform{
 						{
 							Head:  "http://test.com",
-							Files: []index.FileOperation{{"", ""}},
+							Files: []index.FileOperation{{From: "", To: ""}},
 							Bin:   "bin",
 							Selector: &v1.LabelSelector{
 								MatchLabels: map[string]string{"os": "linux"},
 							},
 						}, {
 							Head:  "http://test.com",
-							Files: []index.FileOperation{{"", ""}},
+							Files: []index.FileOperation{{From: "", To: ""}},
 							Bin:   "bin",
 							Selector: &v1.LabelSelector{
 								MatchLabels: map[string]string{"os": "linux", "arch": "arm"},

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -16,13 +16,146 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
-	"sigs.k8s.io/krew/pkg/index"
-
+	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/krew/pkg/constants"
+	"sigs.k8s.io/krew/pkg/index"
+	"sigs.k8s.io/krew/pkg/testutil"
 )
+
+func TestValidateManifestFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  string
+		plugin    *index.Plugin
+		shouldErr bool
+		errMsg    string
+	}{
+		{
+			name:      "manifest does not exist",
+			manifest:  "test.yaml",
+			shouldErr: true,
+			errMsg:    "failed to read plugin file",
+		},
+		{
+			name:     "manifest has wrong file ending",
+			manifest: "test.yml",
+			plugin: &index.Plugin{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			shouldErr: true,
+			errMsg:    "expected manifest extension '.yaml'",
+		},
+		{
+			name:     "manifest validation fails",
+			manifest: "test.yaml",
+			plugin: &index.Plugin{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "wrong-name",
+				},
+			},
+			shouldErr: true,
+			errMsg:    "plugin validation error",
+		},
+		{
+			name:     "architecture selector not supported",
+			manifest: "test.yaml",
+			plugin: &index.Plugin{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: index.PluginSpec{
+					ShortDescription: "test",
+					Platforms: []index.Platform{{
+						Head:  "http://test.com",
+						Files: []index.FileOperation{{"", ""}},
+						Bin:   "bin",
+						Selector: &v1.LabelSelector{
+							MatchLabels: map[string]string{"os": "darwin", "arch": "arm"},
+						},
+					}},
+				},
+			},
+			shouldErr: true,
+			errMsg:    "doesn't match any supported platforms",
+		},
+		{
+			name:     "overlapping platform selectors",
+			manifest: "test.yaml",
+			plugin: &index.Plugin{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: index.PluginSpec{
+					ShortDescription: "test",
+					Platforms: []index.Platform{
+						{
+							Head:  "http://test.com",
+							Files: []index.FileOperation{{"", ""}},
+							Bin:   "bin",
+							Selector: &v1.LabelSelector{
+								MatchLabels: map[string]string{"os": "linux"},
+							},
+						}, {
+							Head:  "http://test.com",
+							Files: []index.FileOperation{{"", ""}},
+							Bin:   "bin",
+							Selector: &v1.LabelSelector{
+								MatchLabels: map[string]string{"os": "linux", "arch": "arm"},
+							},
+						}},
+				},
+			},
+			shouldErr: true,
+			errMsg:    "overlapping platform selectors found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmp, cleanup := testutil.NewTempDir(t)
+			defer cleanup()
+			if test.plugin != nil {
+				content, err := yaml.Marshal(test.plugin)
+				if err != nil {
+					t.Fatal(err)
+				}
+				tmp.Write(test.manifest, content)
+			}
+
+			err := validateManifestFile(tmp.Path(test.manifest))
+			if test.shouldErr {
+				if err == nil {
+					t.Errorf("Expected an error '%s' but found none", test.errMsg)
+				} else if !strings.Contains(err.Error(), test.errMsg) {
+					t.Errorf("Error '%s' should contain error message '%s'", err, test.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but found '%s'", err)
+				}
+			}
+		})
+	}
+}
 
 func Test_selectorMatchesOSArch(t *testing.T) {
 	type args struct {

--- a/hack/check-code-patterns.sh
+++ b/hack/check-code-patterns.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+out="$( find . -name '*_test.go' -not -path './vendor/*' -print0 | xargs -0 grep -En 'ioutil\.TempDir' || [[ $? == 123 ]] )"
+if [[ -n "$out" ]]; then
+  echo >&2 "You used ioutil.TempDir in tests, use 'testutil.NewTempDir()' instead:"
+  echo >&2 "$out"
+  exit 1
+fi

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,4 +2,5 @@ package constants
 
 const (
 	CurrentAPIVersion = "krew.googlecontainertools.github.com/v1alpha2"
+	PluginKind        = "Plugin"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	CurrentAPIVersion = "krew.googlecontainertools.github.com/v1alpha2"
+)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package constants
 
 const (

--- a/pkg/index/types.go
+++ b/pkg/index/types.go
@@ -21,8 +21,8 @@ import (
 // Plugin is a top-level type.
 // TODO(lbb): Add deepcopy code generation.
 type Plugin struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata"`
 
 	Spec PluginSpec `json:"spec"`
 }

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -19,10 +19,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-)
-
-const (
-	currentAPIVersion = "krew.googlecontainertools.github.com/v1alpha2"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 var (
@@ -48,7 +45,7 @@ func IsSafePluginName(name string) bool {
 }
 
 func isSupportedAPIVersion(apiVersion string) bool {
-	return apiVersion == currentAPIVersion
+	return apiVersion == constants.CurrentAPIVersion
 }
 
 // Validate TODO(lbb)

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -54,6 +54,10 @@ func (p Plugin) Validate(name string) error {
 		return errors.Errorf("plugin manifest has apiVersion=%q, not supported in this version of krew (try updating plugin index or install a newer version of krew)", p.APIVersion)
 	}
 
+	if p.Kind != constants.PluginKind {
+		return errors.Errorf("plugin manifest has kind=%q, but only 'Plugin' is supported", p.Kind)
+	}
+
 	if !IsSafePluginName(name) {
 		return errors.Errorf("the plugin name %q is not allowed, must match %q", name, safePluginRegexp.String())
 	}

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -55,7 +55,7 @@ func (p Plugin) Validate(name string) error {
 	}
 
 	if p.Kind != constants.PluginKind {
-		return errors.Errorf("plugin manifest has kind=%q, but only 'Plugin' is supported", p.Kind)
+		return errors.Errorf("plugin manifest has kind=%q, but only %q is supported", p.Kind, constants.PluginKind)
 	}
 
 	if !IsSafePluginName(name) {

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -106,7 +106,10 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "validate success",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -130,7 +133,10 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "bad api version",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: "core/v1"},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "core/v1",
+					Kind:       constants.PluginKind,
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -151,9 +157,39 @@ func TestPlugin_Validate(t *testing.T) {
 			wantErr:    true,
 		},
 		{
+			name: "wrong kind",
+			fields: fields{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       "not-Plugin",
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: PluginSpec{
+					Version:          "",
+					ShortDescription: "short",
+					Description:      "",
+					Caveats:          "",
+					Homepage:         "",
+					Platforms: []Platform{{
+						Head:     "http://example.com",
+						URI:      "",
+						Sha256:   "",
+						Selector: nil,
+						Files:    []FileOperation{{"", ""}},
+						Bin:      "foo",
+					}},
+				},
+			},
+			pluginName: "foo",
+			wantErr:    true,
+		},
+		{
 			name: "no short description",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -176,7 +212,10 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "no file operations",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -199,7 +238,10 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "wrong plugin name",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "wrong-name"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -222,7 +264,10 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "unsafe plugin name",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: constants.CurrentAPIVersion,
+					Kind:       constants.PluginKind,
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "../foo"},
 				Spec: PluginSpec{
 					Version:          "",

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func Test_IsSafePluginName(t *testing.T) {
@@ -105,7 +106,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "validate success",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -152,7 +153,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "no short description",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -175,7 +176,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "no file operations",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -198,7 +199,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "wrong plugin name",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
 				ObjectMeta: metav1.ObjectMeta{Name: "wrong-name"},
 				Spec: PluginSpec{
 					Version:          "",
@@ -221,7 +222,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "unsafe plugin name",
 			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				TypeMeta:   metav1.TypeMeta{APIVersion: constants.CurrentAPIVersion},
 				ObjectMeta: metav1.ObjectMeta{Name: "../foo"},
 				Spec: PluginSpec{
 					Version:          "",

--- a/pkg/testutil/TempDir.go
+++ b/pkg/testutil/TempDir.go
@@ -1,0 +1,71 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type TempDir struct {
+	t    *testing.T
+	root string
+}
+
+// NewTempDir creates a temporary directory and a cleanup function.
+// It is the responsibility of calling code to call cleanup when done.
+func NewTempDir(t *testing.T) (tmpDir *TempDir, cleanup func()) {
+	t.Helper()
+	root, err := ioutil.TempDir("", "krew-test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	tmpDir = &TempDir{t: t, root: root}
+
+	return tmpDir, func() { os.RemoveAll(root) }
+}
+
+// Root returns the root of the temporary directory.
+func (td *TempDir) Root() string {
+	return td.root
+}
+
+// Path returns the path to a file in the temp directory.
+// The input file is expected to use '/' as directory separator regardless of the host OS.
+func (td *TempDir) Path(file string) string {
+	td.t.Helper()
+	pathElems := []string{td.root}
+	pathElems = append(pathElems, strings.Split(file, "/")...)
+	return filepath.Join(pathElems...)
+}
+
+// Write creates a file containing content in the temporary directory.
+func (td *TempDir) Write(file string, content []byte) *TempDir {
+	td.t.Helper()
+	td.failIfErr(os.MkdirAll(filepath.Dir(td.Path(file)), os.ModePerm))
+	return td.failIfErr(ioutil.WriteFile(td.Path(file), content, os.ModePerm))
+}
+
+func (td *TempDir) failIfErr(err error) *TempDir {
+	td.t.Helper()
+	if err != nil {
+		td.t.Fatal(err)
+	}
+	return td
+}


### PR DESCRIPTION
This PR now validates the file extension in the krew manifest validator.

Also, krew now expects `kind: Plugin`, which was not validated at all.

Last, it adds a test util to create and cleanup temporary directories. Some uses of vanilla `ioutil.TempDir` were updated with the new utility.

Fix #190 