### PR TITLE
Fix IndexUrl to point to right url

### DIFF
--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -26,7 +26,7 @@ import (
 )
 
 // IndexURI points to the upstream index.
-const IndexURI = "https://sigs.k8s.io/krew-index.git"
+const IndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{


### PR DESCRIPTION
krew update fails with:
fatal: repository 'https://sigs.k8s.io/krew-index.git/'
not found\n": exit status 128

