### PR TITLE
More integration tests

### DIFF
--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -51,7 +51,7 @@ Remarks:
 					names = append(names, name)
 				}
 				sort.Strings(names)
-				fmt.Fprint(os.Stdout, strings.Join(names, "\n"))
+				fmt.Fprintln(os.Stdout, strings.Join(names, "\n"))
 				return nil
 			}
 

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -51,7 +51,7 @@ Remarks:
 					names = append(names, name)
 				}
 				sort.Strings(names)
-				fmt.Fprintln(os.Stdout, strings.Join(names, "\n"))
+				fmt.Fprint(os.Stdout, strings.Join(names, "\n"))
 				return nil
 			}
 

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -59,16 +59,6 @@ hack/make-binaries.sh
 hack/run-integration-tests.sh
 ```
 
-The above builds binaries for all supported platforms.
-Building only for your platform produces a slightly different image but will
-work in most circumstances:
-
-```bash
-go build ./cmd/krew
-# you need to specify your local krew binary when using this method:
-hack/run-integration-tests.sh ./krew
-```
-
 ## Testing `krew` in a sandbox
 
 After making changes to krew, you should also check that it behaves as expected.

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -44,8 +44,13 @@ install_kubectl_if_needed() {
   fi
 }
 
-install_kubectl_if_needed
 KREW_BINARY=$(readlink -f "${1:-$KREW_BINARY_DEFAULT}")  # needed for `kubectl krew` in tests
+if [[ ! -x "${KREW_BINARY}" ]]; then
+  echo "Did not find $KREW_BINARY. You need to build krew before running the integration tests"
+  exit 1
+fi
 export KREW_BINARY
+
+install_kubectl_if_needed
 
 go test -v ./...

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -18,7 +18,9 @@ set -euo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BINDIR="${SCRIPTDIR}/../out/bin"
-KREW_BINARY_DEFAULT="$BINDIR/krew-linux_amd64"
+GOOS="$(go env GOOS)"
+GOARCH="$(go env GOARCH)"
+KREW_BINARY_DEFAULT="$BINDIR/krew-${GOOS}_${GOARCH}"
 
 if [[ "$#" -gt 0 && ( "$1" = '-h' || "$1" = '--help' ) ]]; then
   cat <<EOF

--- a/test/krew_test.go
+++ b/test/krew_test.go
@@ -162,6 +162,7 @@ func TestKrewUpdate(t *testing.T) {
 	test, cleanup := krew.NewTest(t)
 	defer cleanup()
 
+	// nb do not call WithIndex() here
 	test.Krew("update").RunOrFail()
 	plugins := lines(test.Krew("search").RunOrFailOutput())
 	if len(plugins) < 10 {

--- a/test/krew_test.go
+++ b/test/krew_test.go
@@ -104,35 +104,22 @@ func TestKrewSearchOne(t *testing.T) {
 func TestKrewInfo(t *testing.T) {
 	skipShort(t)
 
-	tests := []struct {
-		name      string
-		plugin    string
-		shouldErr bool
-	}{
-		{
-			name:   "should not fail for a valid plugin",
-			plugin: validPlugin,
-		},
-		{
-			name:      "should fail for an invalid plugin",
-			plugin:    "invalid-plugin",
-			shouldErr: true,
-		},
-	}
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			test, cleanup := krew.NewTest(t)
-			defer cleanup()
+	test.WithIndex().Krew("info", validPlugin).RunOrFail()
+}
 
-			err := test.WithIndex().Krew("info", tt.plugin).Run()
-			if tt.shouldErr && err == nil {
-				t.Errorf("Expected `krew info %s` to fail", tt.plugin)
-			}
-			if !tt.shouldErr && err != nil {
-				t.Errorf("Expected `krew info %s` not to fail", tt.plugin)
-			}
-		})
+func TestKrewInfoInvalidPlugin(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	plugin := "invalid-plugin"
+	err := test.WithIndex().Krew("info", plugin).Run()
+	if err == nil {
+		t.Errorf("Expected `krew info %s` to fail", plugin)
 	}
 }
 

--- a/test/krew_test.go
+++ b/test/krew_test.go
@@ -179,8 +179,9 @@ func skipShort(t *testing.T) {
 }
 
 func lines(in []byte) []string {
-	if string(in) == "" {
+	trimmed := strings.TrimRight(string(in), " \t\n")
+	if trimmed == "" {
 		return nil
 	}
-	return strings.Split(string(in), "\n")
+	return strings.Split(trimmed, "\n")
 }

--- a/test/krew_test.go
+++ b/test/krew_test.go
@@ -16,6 +16,8 @@
 package test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/krew/test/krew"
@@ -25,6 +27,26 @@ const (
 	// validPlugin is a valid plugin with a small download size
 	validPlugin = "konfig"
 )
+
+func TestKrewHelp(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	test.Krew("help").RunOrFail()
+}
+
+func TestUnknownCommand(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	if err := test.Krew("foobar").Run(); err == nil {
+		t.Errorf("Expected `krew foobar` to fail")
+	}
+}
 
 func TestKrewInstall(t *testing.T) {
 	skipShort(t)
@@ -36,13 +58,100 @@ func TestKrewInstall(t *testing.T) {
 	test.Call(validPlugin, "--help").RunOrFail()
 }
 
-func TestKrewHelp(t *testing.T) {
+func TestKrewUninstall(t *testing.T) {
 	skipShort(t)
 
 	test, cleanup := krew.NewTest(t)
 	defer cleanup()
 
-	test.Krew("help").RunOrFail()
+	test.WithIndex().Krew("install", validPlugin).RunOrFailOutput()
+	test.Krew("uninstall", validPlugin).RunOrFailOutput()
+	if err := test.Call(validPlugin, "--help").Run(); err == nil {
+		t.Errorf("Expected the plugin to be uninstalled")
+	}
+}
+
+func TestKrewSearchAll(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	output := test.WithIndex().Krew("search").RunOrFailOutput()
+	if plugins := strings.Split(string(output), "\n"); len(plugins) < 10 {
+		// the first line is the header
+		t.Errorf("Expected at least %d plugins", len(plugins)-1)
+	}
+}
+
+func TestKrewSearchOne(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	output := test.WithIndex().Krew("search", "krew").RunOrFailOutput()
+	plugins := strings.Split(string(output), "\n")
+	if len(plugins) < 2 {
+		t.Errorf("Expected krew to be a valid plugin")
+	}
+	if !strings.HasPrefix(plugins[1], "krew ") {
+		t.Errorf("The first match should be krew")
+	}
+}
+
+func TestKrewInfo(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	output := test.WithIndex().Krew("info", validPlugin).RunOrFailOutput()
+	if !strings.HasPrefix(string(output), "NAME: "+validPlugin) {
+		t.Errorf("The info output should begin with the name header")
+	}
+}
+
+func TestKrewVersion(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	output := test.Krew("version").RunOrFailOutput()
+
+	requiredSubstrings := []string{
+		"IsPlugin",
+		fmt.Sprintf("BasePath        %s", test.Root()),
+		"ExecutedVersion",
+		"GitTag",
+		"GitCommit",
+		"IndexURI        https://github.com/kubernetes-sigs/krew-index.git",
+		"IndexPath",
+		"InstallPath",
+		"DownloadPath",
+		"BinPath",
+	}
+
+	for _, s := range requiredSubstrings {
+		if !strings.Contains(string(output), s) {
+			t.Errorf("Expected to find %q in output of `krew version`", s)
+		}
+	}
+}
+
+func TestKrewUpdate(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := krew.NewTest(t)
+	defer cleanup()
+
+	test.Krew("update").RunOrFail()
+	output := test.Krew("search").RunOrFailOutput()
+	if plugins := strings.Split(string(output), "\n"); len(plugins) < 10 {
+		// the first line is the header
+		t.Errorf("Less than %d plugins found, `krew update` most likely failed unless TestKrewSearchAll also failed", len(plugins)-1)
+	}
 }
 
 func skipShort(t *testing.T) {


### PR DESCRIPTION
These are based on #203 and should be merged after that one. Reviewing before #203 is merged makes also no sense :-/

The tests currently cover the happy path of all subcommands excluding `krew upgrade`. Upgrade is a special case because it needs two versions of a valid plugin. That will be difficult to set up and may be better in a separate PR.