### PR TITLE
Make corneliusweig a maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,3 +2,4 @@ aliases:
   krew-maintainers:
     - ahmetb
     - juanvallejo
+    - corneliusweig


### PR DESCRIPTION
Adding corneliusweig to owners. He has been consistently helping both with
krew and krew-index repositories in terms of:
- developing plugins himself
- taking a stab at krew machinery with large scale code refactors
- adding integration test suite to the project
- adding more validation and test cases
- increasing developer documentation

Some of his notable work:
- https://github.com/kubernetes-sigs/krew/pull/195
- https://github.com/kubernetes-sigs/krew/pull/183
- https://github.com/kubernetes-sigs/krew/pull/191
- https://github.com/kubernetes-sigs/krew/pull/201
- https://github.com/kubernetes-sigs/krew/pull/202
- https://github.com/kubernetes-sigs/krew/pull/203
- https://github.com/kubernetes-sigs/krew/pull/208

He is familiar with the codebase enough to officially review and approve code.