### PR TITLE
Fix readme for wrong use of fish subshell in string

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Read the [User Guide](./docs/USER_GUIDE.md) for detailed documentation.
 
     ```fish
     begin
-      set -x; cd "(mktemp -d)" &&
+      set -x; set temp_dir (mktemp -d); cd "$temp_dir" &&
       curl -fsSLO "https://storage.googleapis.com/krew/v0.2.1/krew.{tar.gz,yaml}" &&
       tar zxvf krew.tar.gz &&
       set KREWNAME krew-(uname | tr '[:upper:]' '[:lower:]')_amd64 &&
       ./$KREWNAME install \
         --manifest=krew.yaml --archive=krew.tar.gz &&
-      set -e KREWNAME
+      set -e KREWNAME; set -e temp_dir
     end
     ```
 3. Add `$HOME/.krew/bin` directory to your PATH environment variable. To do


### PR DESCRIPTION
The scripts fails and outputs an error `cd: The directory '(mktemp -d)' does not exist`. This error appears because `()` in strings aren't generally recognized as subshells in fish. To fix this I set a variable which we use to `cd` to. There seems to be no way to quote subshell commands in fish correctly.