### PR TITLE
hack: move out install_kubectl_if_needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 - hack/run-lint.sh
 - go test -v -short -coverprofile=coverage.txt -covermode=atomic ./...
 - hack/make-all.sh
+- hack/ensure-kubectl-installed.sh
 - hack/run-integration-tests.sh
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/hack/ensure-kubectl-installed.sh
+++ b/hack/ensure-kubectl-installed.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+install_kubectl_if_needed() {
+  if hash kubectl 2>/dev/null; then
+    echo >&2 "using kubectl from the host system and not reinstalling"
+  else
+    local bin_dir
+    bin_dir="$(go env GOPATH)/bin"
+    local -r kubectl_version='v1.14.2'
+    local -r kubectl_path="${bin_dir}/kubectl"
+    local goos goarch kubectl_url
+    goos="$(go env GOOS)"
+    goarch="$(go env GOARCH)"
+    kubectl_url="https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/${goos}/${goarch}/kubectl"
+
+    mkdir -p "${bin_dir}"
+    curl --fail --show-error --silent --location --output "$kubectl_path" "${kubectl_url}"
+    chmod +x "$kubectl_path"
+    echo >&2 "installed kubectl to ${kubectl_path}"
+  fi
+}
+
+install_kubectl_if_needed

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -31,26 +31,11 @@ EOF
   exit 0
 fi
 
-install_kubectl_if_needed() {
-  if hash kubectl 2>/dev/null; then
-    echo 'using kubectl from the host system'
-  else
-    # install kubectl
-    local -r KUBECTL_VERSION='v1.14.2'
-    local -r KUBECTL_BINARY="$BINDIR/kubectl"
-    curl -fSsLo "$KUBECTL_BINARY" https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-    chmod +x "$KUBECTL_BINARY"
-    export PATH="$BINDIR:$PATH"
-  fi
-}
-
 KREW_BINARY=$(readlink -f "${1:-$KREW_BINARY_DEFAULT}")  # needed for `kubectl krew` in tests
 if [[ ! -x "${KREW_BINARY}" ]]; then
   echo "Did not find $KREW_BINARY. You need to build krew before running the integration tests"
   exit 1
 fi
 export KREW_BINARY
-
-install_kubectl_if_needed
 
 go test -v ./...


### PR DESCRIPTION
- install appropriate kubectl (goos/goarch)
- save it to $GOPATH/bin since "export $PATH" won't work outside a particular
  script
- lowercase naming for local variables

Fixes #210.