### PR TITLE
Put local imports in a separate import group

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+# options for analysis running
+run:
+  # which dirs to skip: they won't be analyzed;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but next dirs are always skipped independently
+  # from this option's value:
+  #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs:
+    - hack
+    - docs
+
+linters:
+  enable:
+    - gocritic
+    - goimports
+    - golint
+    - gosimple
+    - interfacer
+    - maligned
+    - misspell
+    - unconvert
+    - unparam
+    - stylecheck
+    - staticcheck
+    - structcheck
+    - prealloc
+  disable:
+    - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,10 @@
+# all available settings of specific linters
+linters-settings:
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: sigs.k8s.io/krew
+
 # options for analysis running
 run:
   # which dirs to skip: they won't be analyzed;

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/krew/pkg/installation"
 )
 

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -18,14 +18,14 @@ import (
 	"flag"
 	"os"
 
-	isatty "github.com/mattn/go-isatty"
-	"github.com/pkg/errors"
-	"sigs.k8s.io/krew/pkg/environment"
-	"sigs.k8s.io/krew/pkg/gitutil"
-
 	"github.com/golang/glog"
+	"github.com/mattn/go-isatty"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/krew/pkg/environment"
+	"sigs.k8s.io/krew/pkg/gitutil"
 )
 
 var (

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/krew/pkg/index/indexscanner"
-
 	"github.com/sahilm/fuzzy"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/krew/pkg/index"
+	"sigs.k8s.io/krew/pkg/index/indexscanner"
 	"sigs.k8s.io/krew/pkg/installation"
 )
 

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
-	"sigs.k8s.io/krew/pkg/installation"
-
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/krew/pkg/installation"
 )
 
 // uninstallCmd represents the uninstall command

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/gitutil"
 )

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/environment"
 	"sigs.k8s.io/krew/pkg/version"

--- a/cmd/krew/main.go
+++ b/cmd/krew/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"github.com/golang/glog"
+
 	"sigs.k8s.io/krew/cmd/krew/cmd"
 )
 

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 	"sigs.k8s.io/krew/pkg/testutil"

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -31,7 +31,7 @@ go get golang.org/x/tools/cmd/goimports
 and run:
 
 ```bash
-goimports -w cmd pkg
+goimports -local sigs.k8s.io/krew -w cmd pkg
 ```
 
 In addition, a boilerplate license header is expected in all source files.

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -31,7 +31,7 @@ go get golang.org/x/tools/cmd/goimports
 and run:
 
 ```bash
-goimports -local sigs.k8s.io/krew -w cmd pkg
+goimports -local sigs.k8s.io/krew -w cmd pkg test
 ```
 
 In addition, a boilerplate license header is expected in all source files.

--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -16,28 +16,11 @@
 
 set -euo pipefail
 
-SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
 if ! [[ -x "$GOPATH/bin/golangci-lint" ]]
 then
    echo 'Installing golangci-lint'
    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$GOPATH/bin" v1.16.0
 fi
 
-"$GOPATH/bin/golangci-lint" run \
-		--no-config \
-		-D errcheck \
-		-E gocritic \
-		-E goimports \
-		-E golint \
-		-E gosimple \
-		-E interfacer \
-		-E maligned \
-		-E misspell \
-		-E unconvert \
-		-E unparam \
-		-E stylecheck \
-		-E staticcheck \
-		-E structcheck \
-		-E prealloc \
-		--skip-dirs hack,docs
+# configured by .golangci.yml
+"$GOPATH/bin/golangci-lint" run

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-files=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -l -s)
+set -euo pipefail
+
+files=$(find . -name "*.go" -not -path './vendor/*' -print0 | xargs -0 gofmt -l -s)
 if [[ $files ]]; then
     echo "Gofmt errors in files:"
     echo "$files"
-    diff=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -d -s)
+    diff=$(find . -name "*.go" -not -path './vendor/*' -print0 | xargs -0 gofmt -d -s)
     echo "$diff"
     exit 1
 fi

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+
 	"sigs.k8s.io/krew/pkg/testutil"
 )
 

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -248,12 +248,12 @@ func Test_download(t *testing.T) {
 			}
 			downloadedData, err := ioutil.ReadAll(io.NewSectionReader(reader, 0, size))
 			if err != nil {
-				t.Errorf("failed to read downlaod data: %v", err)
+				t.Errorf("failed to read download data: %v", err)
 				return
 			}
 			wantData, err := ioutil.ReadAll(io.NewSectionReader(tt.wantReader, 0, tt.wantSize))
 			if err != nil {
-				t.Errorf("failed to read downlaod data: %v", err)
+				t.Errorf("failed to read download data: %v", err)
 				return
 			}
 

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/client-go/util/homedir"
+
 	"sigs.k8s.io/krew/pkg/testutil"
 )
 

--- a/pkg/index/indexscanner/scanner.go
+++ b/pkg/index/indexscanner/scanner.go
@@ -23,11 +23,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-	"sigs.k8s.io/krew/pkg/index"
-
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"sigs.k8s.io/krew/pkg/index"
 )
 
 // LoadPluginListFromFS will parse and retrieve all plugin files.

--- a/pkg/index/indexscanner/scanner_test.go
+++ b/pkg/index/indexscanner/scanner_test.go
@@ -83,7 +83,7 @@ func Test_readIndexFile(t *testing.T) {
 				return
 			}
 			if !sel.Matches(tt.matchFirst) || sel.Matches(neverMatch) {
-				t.Errorf("readIndexFile() didn't parse label selector propperly: %##v", sel)
+				t.Errorf("readIndexFile() didn't parse label selector properly: %##v", sel)
 				return
 			}
 		})

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"sigs.k8s.io/krew/pkg/constants"
 )
 

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/krew/pkg/constants"
 )
 

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -20,13 +20,13 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
 	"sigs.k8s.io/krew/pkg/download"
 	"sigs.k8s.io/krew/pkg/environment"
 	"sigs.k8s.io/krew/pkg/index"
 	"sigs.k8s.io/krew/pkg/pathutil"
-
-	"github.com/golang/glog"
 )
 
 // Plugin Lifecycle Errors

--- a/pkg/installation/util_test.go
+++ b/pkg/installation/util_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/krew/pkg/index"
 )
 

--- a/test/krew/index.go
+++ b/test/krew/index.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+
 	"sigs.k8s.io/krew/pkg/constants"
 )
 

--- a/test/krew/krew.go
+++ b/test/krew/krew.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
 	"sigs.k8s.io/krew/pkg/testutil"
 )
 


### PR DESCRIPTION
As pointed out by @ahmetb  here https://github.com/kubernetes-sigs/krew/pull/195#discussion_r296912755, imports are not sorted correctly. This PR applies standard sort order so that local imports are separated in their own import group. In addition, it also configures the linters to fail if imports are not sorted as expected.