### PR TITLE
Various fixes to integration tests

### DIFF
--- a/hack/ensure-kubectl-installed.sh
+++ b/hack/ensure-kubectl-installed.sh
@@ -29,6 +29,7 @@ install_kubectl_if_needed() {
     goarch="$(go env GOARCH)"
     kubectl_url="https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/${goos}/${goarch}/kubectl"
 
+    echo >&2 "kubectl not detected in environment, downloading ${kubectl_url}"
     mkdir -p "${bin_dir}"
     curl --fail --show-error --silent --location --output "$kubectl_path" "${kubectl_url}"
     chmod +x "$kubectl_path"

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -38,5 +38,4 @@ if [[ ! -x "${KREW_BINARY}" ]]; then
 fi
 export KREW_BINARY
 
-"${SCRIPTDIR}/ensure-kubectl-installed.sh"
 go test -test.v sigs.k8s.io/krew/test

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -18,9 +18,9 @@ set -euo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BINDIR="${SCRIPTDIR}/../out/bin"
-GOOS="$(go env GOOS)"
-GOARCH="$(go env GOARCH)"
-KREW_BINARY_DEFAULT="$BINDIR/krew-${GOOS}_${GOARCH}"
+goos="$(go env GOOS)"
+goarch="$(go env GOARCH)"
+KREW_BINARY_DEFAULT="${BINDIR}/krew-${goos}_${goarch}"
 
 if [[ "$#" -gt 0 && ( "$1" = '-h' || "$1" = '--help' ) ]]; then
   cat <<EOF
@@ -33,9 +33,10 @@ fi
 
 KREW_BINARY=$(readlink -f "${1:-$KREW_BINARY_DEFAULT}")  # needed for `kubectl krew` in tests
 if [[ ! -x "${KREW_BINARY}" ]]; then
-  echo "Did not find $KREW_BINARY. You need to build krew before running the integration tests"
+  echo "Did not find $KREW_BINARY. You need to build krew FOR ${goos}/${goarch} before running the integration tests."
   exit 1
 fi
 export KREW_BINARY
 
-go test -v ./...
+"${SCRIPTDIR}/ensure-kubectl-installed.sh"
+go test -test.v sigs.k8s.io/krew/test

--- a/test/krew/krew.go
+++ b/test/krew/krew.go
@@ -85,12 +85,12 @@ func augmentPATH(t *testing.T, v string) string {
 	return v + string(os.PathListSeparator) + curPath
 }
 
-func (it *ITest) lookExecutable(file string) error {
+func (it *ITest) lookupExecutable(file string) error {
 	orig := os.Getenv("PATH")
 	defer func() { os.Setenv("PATH", orig) }()
 
 	binPath := filepath.Join(it.Root(), "bin")
-	os.Setenv("PATH", binPath+string(os.PathListSeparator)+binPath)
+	os.Setenv("PATH", binPath)
 
 	_, err := exec.LookPath(file)
 	return err
@@ -98,7 +98,8 @@ func (it *ITest) lookExecutable(file string) error {
 
 // AssertExecutableInPATH asserts that the executable file is in bin path.
 func (it *ITest) AssertExecutableInPATH(file string) {
-	if err := it.lookExecutable(file); err != nil {
+	it.t.Helper()
+	if err := it.lookupExecutable(file); err != nil {
 		it.t.Fatalf("executable %s not in PATH: %+v", file, err)
 	}
 }
@@ -106,7 +107,8 @@ func (it *ITest) AssertExecutableInPATH(file string) {
 // AssertExecutableNotInPATH asserts that the executable file is not in bin
 // path.
 func (it *ITest) AssertExecutableNotInPATH(file string) {
-	if err := it.lookExecutable(file); err == nil {
+	it.t.Helper()
+	if err := it.lookupExecutable(file); err == nil {
 		it.t.Fatalf("executable %s still exists in PATH", file)
 	}
 }

--- a/test/krew_test.go
+++ b/test/krew_test.go
@@ -57,7 +57,7 @@ func TestKrewInstall(t *testing.T) {
 	defer cleanup()
 
 	test.WithIndex().Krew("install", validPlugin).RunOrFailOutput()
-	test.Call(validPlugin, "--help").RunOrFail()
+	test.AssertExecutableInPATH("kubectl-" + validPlugin)
 }
 
 func TestKrewUninstall(t *testing.T) {
@@ -68,9 +68,7 @@ func TestKrewUninstall(t *testing.T) {
 
 	test.WithIndex().Krew("install", validPlugin).RunOrFailOutput()
 	test.Krew("uninstall", validPlugin).RunOrFailOutput()
-	if err := test.Call(validPlugin, "--help").Run(); err == nil {
-		t.Errorf("Expected the plugin to be uninstalled")
-	}
+	test.AssertExecutableNotInPATH("kubectl-" + validPlugin)
 }
 
 func TestKrewSearchAll(t *testing.T) {


### PR DESCRIPTION
I was hoping to write more integration tets, but along the way I noticed some
issues with how we run integration tests.
This PR addressses few things about the integration tests that bugged me.

- do not actually run the test plugin, it's out of our tool's scope
- run only integration tests from the script (previously ./...)
- DO NOT use the host-krew, require KREW_BINARY to be set (we almost never want to use host-krew)

Fixes #224
Fixes #225
Fixes #227