### PR TITLE
Make output of `krew search` easier to read

### DIFF
--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -71,7 +71,7 @@ Remarks:
 }
 
 func printTable(out io.Writer, columns []string, rows [][]string) error {
-	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(w, strings.Join(columns, "\t"))
 	fmt.Fprintln(w)
 	for _, values := range rows {

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -73,18 +74,18 @@ Examples:
 		}
 
 		var rows [][]string
-		cols := []string{"NAME", "DESCRIPTION", "STATUS"}
+		cols := []string{"NAME", "DESCRIPTION", "INSTALLED"}
 		for _, name := range matchNames {
 			plugin := pluginMap[name]
 			var status string
 			if _, ok := installed[name]; ok {
-				status = "installed"
+				status = "yes"
 			} else if _, ok, err := plugin.Spec.GetMatchingPlatform(); err != nil {
 				return errors.Wrapf(err, "failed to get the matching platform for plugin %s", name)
 			} else if ok {
-				status = "available"
+				status = "no"
 			} else {
-				status = "unavailable"
+				status = "unavailable on " + runtime.GOOS
 			}
 			rows = append(rows, []string{name, limitString(plugin.Spec.ShortDescription, 50), status})
 		}


### PR DESCRIPTION
So far, the last column was labelled with `STATUS` and had three options
(installed, available, unavailable). This was hard to read because
installed and available have the same length, and `unavailable` was not
specific.

Now, the column is labelled `INSTALLED` with values
yes/no/unavailable on \<PLATFORM\>

In addition, I increased the padding between columns to _two spaces_ which looks cleaner. WDYT?

---
Sample output:
```
NAME                            DESCRIPTION                                         INSTALLED
access-matrix                   Show an access matrix for server resources          no
bulk-action                     Do bulk actions on Kubernetes resources.            unavailable on linux
ca-cert                         Print the PEM CA certificate of the current clu...  yes
```

Fix #250 