### PR TITLE
hack: add make-binary.sh for local builds

### DIFF
--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -22,7 +22,7 @@ git remote set-url origin --push no_push   # to avoid pushes
 Krew adheres to standard `golang` code formatting conventions, and also expects
 imports sorted properly.
 To automatically format code appropriately, install
-[`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports) via 
+[`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports) via:
 
 ```bash
 go get golang.org/x/tools/cmd/goimports
@@ -38,6 +38,11 @@ In addition, a boilerplate license header is expected in all source files.
 
 _All new code should be covered by tests._
 
+## Compiling
+
+Use `hack/make-binary.sh` to make a binary in `out/bin/` for your current
+platform. You can use `hack/make-binaries.sh` to build binaries for all
+supported platforms.
 
 ## Running tests
 
@@ -55,7 +60,7 @@ In addition, there are integration tests to cover high-level krew functionality.
 To run integration tests, you will need to build the `krew` binary beforehand:
 
 ```bash
-hack/make-binaries.sh
+hack/make-binary.sh
 hack/run-integration-tests.sh
 ```
 

--- a/hack/make-binaries.sh
+++ b/hack/make-binaries.sh
@@ -14,28 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script builds krew binaries for all supported platforms (or those os/arch
+# combinations specified via OSARCH variable).
+
 set -e -o pipefail
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if ! command -v "gox" &>/dev/null; then
   echo >&2 "gox not installed in PATH, run hack/install-gox.sh."
   exit 1
 fi
 
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "${SCRIPTDIR}/.."
 
-DEFAULT_OSARCH="darwin/amd64 windows/amd64 linux/amd64 linux/arm"
+
+supported_platforms="darwin/amd64 windows/amd64 linux/amd64 linux/arm"
 version_pkg="sigs.k8s.io/krew/pkg/version"
 
-rm -rf out/
+cd "${SCRIPTDIR}/.."
+rm -rf -- "out/"
 
 # Builds
-echo >&2 "Building binaries for: ${OSARCH:-$DEFAULT_OSARCH}"
+echo >&2 "Building binaries for: ${OSARCH:-$supported_platforms}"
 git_rev="${SHORT_SHA:-$(git rev-parse --short HEAD)}"
 git_tag="${TAG_NAME:-$(git describe --tags --dirty --always)}"
 echo >&2 "(Stamping with git tag=${git_tag} rev=${git_rev})"
 
-env CGO_ENABLED=0 gox -osarch="${OSARCH:-$DEFAULT_OSARCH}" \
+env CGO_ENABLED=0 gox -osarch="${OSARCH:-$supported_platforms}" \
   -tags netgo \
   -mod readonly \
   -ldflags="-w -X ${version_pkg}.gitCommit=${git_rev} \

--- a/hack/make-binary.sh
+++ b/hack/make-binary.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script builds krew binary for the current OS/arch.
+
+set -e -o pipefail
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+exec env OSARCH="$(go env GOOS)/$(go env GOARCH)" \
+    "${SCRIPTDIR}/make-binaries.sh"

--- a/hack/run-in-docker.sh
+++ b/hack/run-in-docker.sh
@@ -46,7 +46,8 @@ fi
 log_ok "Starting docker container with volume mounts:"
 log    "    kubeconfig=${kubeconfig}"
 log    "    kubectl-krew=${krew_bin}"
-log_ok "You can rebuild with make-binaries.sh without restarting the container."
+log_ok "You can rebuild with the following command without restarting the container:"
+log    "    env OSARCH=linux/amd64 hack/make-binaries.sh"
 exec docker run --rm --tty --interactive \
     --volume "${krew_bin}:/usr/local/bin/kubectl-krew" \
     --volume "${kubeconfig}:/etc/kubeconfig" \


### PR DESCRIPTION
I've been finding myself doing a lot of:

    OSARCH=darwin/amd64 hack/make-binaries.sh

this should help with that. I'm mostly making this change for myself.

/kind proposal
/assign @corneliusweig