### PR TITLE
Make files in `spec.platforms[]` optional

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -187,14 +187,14 @@ wildcard may install more files than desired.
 ```
 
 - To copy all files in the `bin/` directory of the extracted archive to
-  the root of your plugin, use the default:
+  the root of your plugin, leave out the `files:` field, which is equivalent to
 
   ```yaml
-      files:   # unspecified, equivalent to [{from: "*", to: "."}]
+      files: [{from: "*", to: "."}]
   ```
   
-  This would copy out binaries for both platforms to the installation
-  directory on user’s machine, despite only one of them will be used:
+  This copies out binaries for both platforms to the installation directory
+  onto the user’s machine, despite only one of them will be used:
   
   ```text
   .

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -104,7 +104,8 @@ spec:
     uri: https://github.com/example/foo/releases/v1.0.zip
     # sha256sum of the file downloaded above:
     sha256: "208fde0b9f42ef71f79864b1ce594a70832c47dc5426e10ca73bf02e54d499d0"
-    files:                     # copy the used files out of the zip archive
+    # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
+    files:
     - from: "/foo-*/unix/*.sh" # path to the files extracted from archive
       to: "."               # '.' refers to the root of plugin install directory
     bin: "./kubectl-foo"  # path to the plugin executable after copying files above
@@ -169,20 +170,12 @@ be installed. You can use the `files` field in the plugin manifest to specify
 which files should be copied into the plugin directory after extracting the
 plugin archive.
 
-The `file:` list specifies the copy operations (like `mv(1) <from> <to>`) to
-the files `from` the archive `to` the installation destination.
+The `files:` list specifies the copy operations (like `mv(1) <from> <to>`) to
+the files `from` the archive `to` the installation destination. If the `files`
+list is unspecified, it defaults to `[{from: "*", to: "."}]`. Mind that a
+wildcard may install more files than desired.
 
-**Example:** Copy all files in the `bin/` directory of the extracted archive to
-the root of your plugin:
-
-```yaml
-    files:
-    - from: bin/*.exe
-      to: .
-```
-
-Given the file operation above, if the extracted plugin archive looked like
-this:
+**Example:** Consider a plugin whose extracted archive looks like
 
 ```text
 .
@@ -193,12 +186,36 @@ this:
     └── kubectl-foo-windows.exe
 ```
 
-The resulting installation directory would up just with:
+- To copy all files in the `bin/` directory of the extracted archive to
+  the root of your plugin, use the default:
 
-```text
-.
-└── krew-foo-windows.exe
-```
+  ```yaml
+      files:   # unspecified, equivalent to [{from: "*", to: "."}]
+  ```
+  
+  This would copy out binaries for both platforms to the installation
+  directory on user’s machine, despite only one of them will be used:
+  
+  ```text
+  .
+  └── krew-foo-windows.exe
+  └── krew-foo-linux
+  ```
+
+- For a more fine-grained control, specify each copy operation:
+
+  ```yaml
+      files:
+      - from: bin/*.exe
+        to: .
+  ```
+
+  This will result in the following files in the installation directory:
+
+  ```text
+  .
+  └── krew-foo-windows.exe
+  ```
 
 #### Specifying plugin executable
 

--- a/pkg/index/indexscanner/testdata/testindex/dontscan.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/dontscan.yaml
@@ -20,6 +20,7 @@ spec:
   platforms:
   - files:
     - from: "*"
+      to: "."
     uri: https://example.com
     sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     selector:
@@ -27,6 +28,7 @@ spec:
       - {key: os, operator: In, values: [macos, linux]}
   - files:
     - from: "*"
+      to: "."
     uri: https://example.com
     sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     selector:

--- a/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
@@ -21,6 +21,7 @@ spec:
   platforms:
   - files:
     - from: "*"
+      to: "."
     uri: https://example.com
     sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     bin: kubectl-bar
@@ -29,6 +30,7 @@ spec:
         os: windows
   - files:
     - from: "*"
+      to: "."
     uri: https://example.com
     sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     bin: kubectl-bar

--- a/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
@@ -21,6 +21,7 @@ spec:
   platforms:
   - files:
     - from: "*"
+      to: "."
     uri: https://example.com
     sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     bin: kubectl-foo
@@ -29,6 +30,7 @@ spec:
       - {key: os, operator: In, values: [macos, linux]}
   - files:
     - from: "*"
+      to: "."
     uri: https://example.com
     sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     bin: kubectl-foo

--- a/pkg/index/validation/validate.go
+++ b/pkg/index/validation/validate.go
@@ -99,19 +99,19 @@ func ValidatePlugin(name string, p index.Plugin) error {
 // validatePlatform checks Platform for structural validity.
 func validatePlatform(p index.Platform) error {
 	if p.URI == "" {
-		return errors.New("URI has to be set")
+		return errors.New("`uri` has to be set")
 	}
 	if p.Sha256 == "" {
-		return errors.New("sha256 sum has to be set")
+		return errors.New("`sha256` sum has to be set")
 	}
 	if !isValidSHA256(p.Sha256) {
-		return errors.Errorf("sha256 value %s is not valid, must match pattern %s", p.Sha256, sha256Pattern)
+		return errors.Errorf("`sha256` value %s is not valid, must match pattern %s", p.Sha256, sha256Pattern)
 	}
 	if p.Bin == "" {
-		return errors.New("bin has to be set")
+		return errors.New("`bin` has to be set")
 	}
 	if err := validateFiles(p.Files); err != nil {
-		return errors.Wrap(err, "files is invalid")
+		return errors.Wrap(err, "`files` is invalid")
 	}
 	if err := validateSelector(p.Selector); err != nil {
 		return errors.Wrap(err, "invalid platform selector")
@@ -124,14 +124,13 @@ func validateFiles(fops []index.FileOperation) error {
 		return nil
 	}
 	if len(fops) == 0 {
-		return errors.New("files has to be unspecified or non-empty")
+		return errors.New("`files` has to be unspecified or non-empty")
 	}
 	for _, op := range fops {
 		if op.From == "" {
-			return errors.New("from field has to be set")
-		}
-		if op.To == "" {
-			return errors.New("to field has to be set")
+			return errors.New("`from` field has to be set")
+		} else if op.To == "" {
+			return errors.New("`to` field has to be set")
 		}
 	}
 	return nil
@@ -161,10 +160,10 @@ func validateSelector(sel *metav1.LabelSelector) error {
 	}
 
 	if sel.MatchLabels != nil && len(sel.MatchLabels) == 0 {
-		return errors.New("matchLabels specified but empty")
+		return errors.New("`matchLabels` specified but empty")
 	}
 	if sel.MatchExpressions != nil && len(sel.MatchExpressions) == 0 {
-		return errors.New("matchExpressions specified but empty")
+		return errors.New("`matchExpressions` specified but empty")
 	}
 
 	return nil

--- a/pkg/index/validation/validate.go
+++ b/pkg/index/validation/validate.go
@@ -110,11 +110,29 @@ func validatePlatform(p index.Platform) error {
 	if p.Bin == "" {
 		return errors.New("bin has to be set")
 	}
-	if len(p.Files) == 0 {
-		return errors.New("can't have a plugin without specifying file operations")
+	if err := validateFiles(p.Files); err != nil {
+		return errors.Wrap(err, "files is invalid")
 	}
 	if err := validateSelector(p.Selector); err != nil {
 		return errors.Wrap(err, "invalid platform selector")
+	}
+	return nil
+}
+
+func validateFiles(fops []index.FileOperation) error {
+	if fops == nil {
+		return nil
+	}
+	if len(fops) == 0 {
+		return errors.New("files has to be unspecified or non-empty")
+	}
+	for _, op := range fops {
+		if op.From == "" {
+			return errors.New("from field has to be set")
+		}
+		if op.To == "" {
+			return errors.New("to field has to be set")
+		}
 	}
 	return nil
 }

--- a/pkg/index/validation/validate_test.go
+++ b/pkg/index/validation/validate_test.go
@@ -146,10 +146,10 @@ func TestValidatePlugin(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "no file operations",
+			name:       "empty file operations",
 			pluginName: "foo",
 			plugin: testutil.NewPlugin().WithName("foo").WithPlatforms(
-				testutil.NewPlatform().WithFiles(nil).V()).V(),
+				testutil.NewPlatform().WithFiles([]index.FileOperation{}).V()).V(),
 			wantErr: true,
 		},
 		{
@@ -190,8 +190,8 @@ func TestValidatePlatform(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:     "no file operations",
-			platform: testutil.NewPlatform().WithFiles(nil).V(),
+			name:     "empty file operations",
+			platform: testutil.NewPlatform().WithFiles([]index.FileOperation{}).V(),
 			wantErr:  true,
 		},
 		{
@@ -278,6 +278,47 @@ func Test_validateSelector(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateSelector(tt.sel); (err != nil) != tt.wantErr {
 				t.Errorf("validateSelector() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []index.FileOperation
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			files:   []index.FileOperation{{From: "here", To: "there"}},
+			wantErr: false,
+		},
+		{
+			name:    "unspecified file operations",
+			files:   nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty file operations",
+			files:   []index.FileOperation{},
+			wantErr: true,
+		},
+		{
+			name:    "empty `to` field in file operations",
+			files:   []index.FileOperation{{From: "present", To: ""}},
+			wantErr: true,
+		},
+		{
+			name:    "empty `from` field in file operations",
+			files:   []index.FileOperation{{From: "", To: "present"}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateFiles(tt.files); (err != nil) != tt.wantErr {
+				t.Errorf("validateFiles() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/index/validation/validate_test.go
+++ b/pkg/index/validation/validate_test.go
@@ -283,7 +283,7 @@ func Test_validateSelector(t *testing.T) {
 	}
 }
 
-func TestValidateFiles(t *testing.T) {
+func Test_validateFiles(t *testing.T) {
 	tests := []struct {
 		name    string
 		files   []index.FileOperation

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -107,6 +107,7 @@ func install(op installOperation, opts InstallOpts) error {
 		return errors.Wrap(err, "failed to download and extract")
 	}
 
+	applyDefaults(&op.platform)
 	if err := moveToInstallDir(op.downloadStagingDir, op.installDir, op.platform.Files); err != nil {
 		return errors.Wrap(err, "failed while moving files to the installation directory")
 	}
@@ -125,6 +126,13 @@ func install(op installOperation, opts InstallOpts) error {
 	}
 	err = createOrUpdateLink(op.binDir, fullPath, op.pluginName)
 	return errors.Wrap(err, "failed to link installed plugin")
+}
+
+func applyDefaults(platform *index.Platform) {
+	if platform.Files == nil {
+		platform.Files = []index.FileOperation{{From: "*", To: "."}}
+		glog.V(4).Infof("file operation not specified, assuming %v", platform.Files)
+	}
 }
 
 // downloadAndExtract downloads the specified archive uri (or uses the provided overrideFile, if a non-empty value)

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -165,11 +165,6 @@ func moveToInstallDir(srcDir, installDir string, fos []index.FileOperation) erro
 	}
 	defer os.RemoveAll(tmp)
 
-	if fos == nil {
-		fos = []index.FileOperation{{From: "*", To: "."}}
-		glog.V(4).Infof("file operation not specified, assuming %v", fos)
-	}
-
 	if err = moveAllFiles(srcDir, tmp, fos); err != nil {
 		return errors.Wrap(err, "failed to move files")
 	}

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -165,6 +165,11 @@ func moveToInstallDir(srcDir, installDir string, fos []index.FileOperation) erro
 	}
 	defer os.RemoveAll(tmp)
 
+	if fos == nil {
+		fos = []index.FileOperation{{From: "*", To: "."}}
+		glog.V(4).Infof("file operation not specified, assuming %v", fos)
+	}
+
 	if err = moveAllFiles(srcDir, tmp, fos); err != nil {
 		return errors.Wrap(err, "failed to move files")
 	}


### PR DESCRIPTION
Many plugins use the pattern to copy all files from the archive into the installation directory. Those plugins always have to specify a file copy operation such as
```yaml
files:
- from: "*"
  to: "."
```

This PR makes the files field completely optional and defaults to the above copy specifier. As discussed in #135, the default copy spec may install too many files. The plugin developer docs therefore explicitly show such an antipattern example.

Close #135