### PR TITLE
Update plugin listings to use install receipts

### DIFF
--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -40,7 +40,7 @@ Remarks:
   the names of the plugins installed. This output can be piped back to the
   "install" command.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			plugins, err := installation.ListInstalledPlugins(paths.InstallPath(), paths.BinPath())
+			plugins, err := installation.ListInstalledPlugins(paths.InstallReceiptsPath())
 			if err != nil {
 				return errors.Wrap(err, "failed to find all installed versions")
 			}

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -53,7 +53,7 @@ Examples:
 			pluginMap[p.Name] = p
 		}
 
-		installed, err := installation.ListInstalledPlugins(paths.InstallPath(), paths.BinPath())
+		installed, err := installation.ListInstalledPlugins(paths.InstallReceiptsPath())
 		if err != nil {
 			return errors.Wrap(err, "failed to load installed plugins")
 		}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -40,7 +40,7 @@ kubectl krew upgrade foo bar"`,
 		var pluginNames []string
 		// Upgrade all plugins.
 		if len(args) == 0 {
-			installed, err := installation.ListInstalledPlugins(paths.InstallPath(), paths.BinPath())
+			installed, err := installation.ListInstalledPlugins(paths.InstallReceiptsPath())
 			if err != nil {
 				return errors.Wrap(err, "failed to find all installed versions")
 			}

--- a/pkg/installation/util.go
+++ b/pkg/installation/util.go
@@ -83,6 +83,10 @@ func getDownloadTarget(index index.Plugin) (version, uri string, fos []index.Fil
 // ListInstalledPlugins returns a list of all install plugins in a
 // name:version format based on the install receipts at the specified dir.
 func ListInstalledPlugins(receiptsDir string) (map[string]string, error) {
+	// TODO(ahmetb): Write unit tests for this method. Currently blocked by
+	// lack of an in-memory recipt object (issue#270) that we can use to save
+	// receipts to a tempdir that can be read from unit tests.
+
 	matches, err := filepath.Glob(filepath.Join(receiptsDir, "*"+constants.ManifestExtension))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to grab receipts directory (%s) for manifests", receiptsDir)

--- a/pkg/receipt/receipt.go
+++ b/pkg/receipt/receipt.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/krew/pkg/index"
+	"sigs.k8s.io/krew/pkg/index/indexscanner"
 )
 
 // Store saves the given plugin at the destination.
@@ -33,4 +34,14 @@ func Store(plugin index.Plugin, dest string) error {
 
 	err = ioutil.WriteFile(dest, yamlBytes, 0644)
 	return errors.Wrapf(err, "write plugin receipt %q", dest)
+}
+
+// Load reads the plugin receipt at the specified destination.
+// If not found, it returns os.IsNotExist error.
+func Load(path string) (*index.Plugin, error) {
+	p, err := indexscanner.ReadPluginFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
 }

--- a/pkg/receipt/receipt.go
+++ b/pkg/receipt/receipt.go
@@ -38,10 +38,6 @@ func Store(plugin index.Plugin, dest string) error {
 
 // Load reads the plugin receipt at the specified destination.
 // If not found, it returns os.IsNotExist error.
-func Load(path string) (*index.Plugin, error) {
-	p, err := indexscanner.ReadPluginFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return &p, nil
+func Load(path string) (index.Plugin, error) {
+	return indexscanner.ReadPluginFile(path)
 }

--- a/pkg/receipt/receipt_test.go
+++ b/pkg/receipt/receipt_test.go
@@ -72,12 +72,12 @@ func TestStore(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
-	p, err := Load(filepath.Join("..", "..", "integration_test", "testdata", "foo.yaml"))
+	// TODO(ahmetb): Avoid reading test data from other packages. It would be
+	// good to have an in-memory Plugin object (issue#270) that we can Store()
+	// first then load here.
+	_, err := Load(filepath.Join("..", "..", "integration_test", "testdata", "foo.yaml"))
 	if err != nil {
 		t.Fatal(err)
-	}
-	if p == nil {
-		t.Fatal("parsed plugin is nil")
 	}
 }
 

--- a/pkg/receipt/receipt_test.go
+++ b/pkg/receipt/receipt_test.go
@@ -15,6 +15,8 @@
 package receipt
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -66,5 +68,22 @@ func TestStore(t *testing.T) {
 
 	if diff := cmp.Diff(&testPlugin, &actual); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	p, err := Load(filepath.Join("..", "..", "integration_test", "testdata", "foo.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p == nil {
+		t.Fatal("parsed plugin is nil")
+	}
+}
+
+func TestLoad_preservesNonExistsError(t *testing.T) {
+	_, err := Load(filepath.Join("foo", "non-existing.yaml"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("returned error is not ENOENT: %+v", err)
 	}
 }


### PR DESCRIPTION
- Changed the way we determine the list of "installed plugins" by looking at
  install receipts directory.
- Added a receipt.Load() method for reading saved install receipts.

/assign @corneliusweig