### PR TITLE
Refactor upgrade machinery to use semver versions

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -121,7 +121,7 @@ Remarks:
 				fmt.Fprintf(os.Stderr, "Installing plugin: %s\n", plugin.Name)
 				err := installation.Install(paths, plugin, *forceDownloadFile)
 				if err == installation.ErrIsAlreadyInstalled {
-					glog.Warningf("Skipping plugin %s, it is already installed", plugin.Name)
+					glog.Warningf("Skipping plugin %q, it is already installed", plugin.Name)
 					continue
 				}
 				if err != nil {

--- a/pkg/download/verifier.go
+++ b/pkg/download/verifier.go
@@ -53,7 +53,7 @@ func (v sha256Verifier) Verify() error {
 	if bytes.Equal(v.wantedHash, v.Sum(nil)) {
 		return nil
 	}
-	return errors.Errorf("checksum does not match, wantReader: %x, got %x", v.wantedHash, v.Sum(nil))
+	return errors.Errorf("checksum does not match, want: %x, got %x", v.wantedHash, v.Sum(nil))
 }
 
 var _ Verifier = trueVerifier{}


### PR DESCRIPTION
This change starts using semver version of plugin manifests to:
- determine if upgrade is needed
- determine if a plugin is installed

by looking at receipts installation directory. It doesn't help with other commands just yet.

This fixes #166, and helps with #277 partially.

Other commands are probably not yet using receipts entirely.