### PR TITLE
Add --no-update-index option to bypass updates

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -29,7 +29,10 @@ import (
 )
 
 func init() {
-	var manifest, forceDownloadFile *string
+	var (
+		manifest, forceDownloadFile *string
+		noUpdateIndex               *bool
+	)
 
 	// installCmd represents the install command
 	installCmd := &cobra.Command{
@@ -140,16 +143,21 @@ Remarks:
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if *manifest == "" {
-				return ensureIndexUpdated(cmd, args)
+			if *manifest != "" {
+				glog.V(4).Infof("--manifest specified, not ensuring plugin index")
+				return nil
 			}
-			glog.V(4).Infof("--manifest specified, not ensuring plugin index")
-			return nil
+			if *noUpdateIndex {
+				glog.V(4).Infof("--no-update-index specified, skipping updating local copy of plugin index")
+				return nil
+			}
+			return ensureIndexUpdated(cmd, args)
 		},
 	}
 
 	manifest = installCmd.Flags().String("manifest", "", "(Development-only) specify plugin manifest directly.")
 	forceDownloadFile = installCmd.Flags().String("archive", "", "(Development-only) force all downloads to use the specified file")
+	noUpdateIndex = installCmd.Flags().Bool("no-update-index", false, "(Experimental) do not update local copy of plugin index before installing")
 
 	rootCmd.AddCommand(installCmd)
 }


### PR DESCRIPTION
This option added to 'install' and 'upgrade' sub-commands allows users
(primarily developers) to test behavior locally (such as upgrades) while
preventing krew from auto-{updating,reverting,resetting} changes to the
local copy of the index repository at $KREW_ROOT/index.

Introducing this flag as "experimental", this way we can delete it if we don't
like it in the future. It's provided as an "escape hatch". An alternative I
can think of is a file like `$dir/.noupdate` existing in the index repo, but
I think this is cleaner.

Two issues that are in my mind currently wrt this change:

1. I can't recide between `--no-update-index` vs `--no-index-update`. In our
   `gcloud` conventions we tend to use `--no-$VERB-$NOUN` so I'm going with
   this.

2. Writing integration tests currently sound unnecessary to me, although it's
   probably possible (we can write files to the per-test index dir, and see if
   they survive krew upgrade and krew install, which don't have to succeed).
   Thoughts?

Fixes #263.