### PR TITLE
test: remove -v from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - hack/verify-boilerplate.sh
 - hack/verify-gofmt.sh
 - hack/run-lint.sh
-- go test -v -short -coverprofile=coverage.txt -covermode=atomic ./...
+- go test -short -coverprofile=coverage.txt -covermode=atomic ./...
 - hack/make-all.sh
 - hack/verify-installation.sh
 - hack/ensure-kubectl-installed.sh

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -47,4 +47,4 @@ fi
 KREW_BINARY="${krew_binary_realpath}"
 export KREW_BINARY
 
-GO111MODULE=on go test -test.v sigs.k8s.io/krew/integration_test
+GO111MODULE=on go test sigs.k8s.io/krew/integration_test

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -44,7 +44,7 @@ print_with_color "$color_blue" 'Running gofmt'
 "$SCRIPTDIR"/verify-gofmt.sh
 
 print_with_color "$color_blue" 'Running tests'
-GO111MODULE=on go test -v -short -race sigs.k8s.io/krew/...
+GO111MODULE=on go test -short -race sigs.k8s.io/krew/...
 
 print_with_color "$color_blue" 'Running linter'
 "$SCRIPTDIR"/run-lint.sh


### PR DESCRIPTION
-v is only useful if you want to see all the test cases that are being run.
I don't think this is useful locally or in the build system. I've been having
trouble scrolling a lot and trying to find the FAIL: line.

Any failed test will still print its t.Log or stdout/stderr printing along with
the test method name, so this should be fine.

/assign @corneliusweig
/kind cleanup