### PR TITLE
pkg/installation: unused pluginVersionFromPath

### DIFF
--- a/pkg/installation/util.go
+++ b/pkg/installation/util.go
@@ -23,17 +23,7 @@ import (
 	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 	"sigs.k8s.io/krew/pkg/installation/receipt"
-	"sigs.k8s.io/krew/pkg/pathutil"
 )
-
-func pluginVersionFromPath(installPath, pluginPath string) (string, error) {
-	// plugin path: {install_path}/{plugin_name}/{version}/...
-	elems, ok := pathutil.IsSubPath(installPath, pluginPath)
-	if !ok || len(elems) < 2 {
-		return "", errors.Errorf("failed to get the version from execution path=%q, with install path=%q", pluginPath, installPath)
-	}
-	return elems[1], nil
-}
 
 func getDownloadTarget(index index.Plugin) (version, sha256sum, uri string, fos []index.FileOperation, bin string, err error) {
 	// TODO(ahmetb): We have many return values from this method, indicating

--- a/pkg/installation/util_test.go
+++ b/pkg/installation/util_test.go
@@ -96,38 +96,3 @@ func testdataPath(t *testing.T) string {
 	}
 	return filepath.Join(pwd, "testdata")
 }
-
-func Test_pluginVersionFromPath(t *testing.T) {
-	type args struct {
-		installPath string
-		pluginPath  string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "normal version",
-			args: args{
-				installPath: filepath.FromSlash("install/"),
-				pluginPath:  filepath.FromSlash("install/foo/HEAD/kubectl-foo"),
-			},
-			want:    "HEAD",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := pluginVersionFromPath(tt.args.installPath, tt.args.pluginPath)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("pluginVersionFromPath() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("pluginVersionFromPath() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}


### PR DESCRIPTION
Removing unused method.

Aside: It would be good to have a lint check that validates that unexposed
methods are not used (maybe even for external methods).

/kind cleanup
/assign @corneliusweig 