### PR TITLE
pkg/installation: cleanup refactoring

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -31,8 +31,8 @@ import (
 
 func init() {
 	var (
-		manifest, forceDownloadFile *string
-		noUpdateIndex               *bool
+		manifest, archiveFileOverride *string
+		noUpdateIndex                 *bool
 	)
 
 	// installCmd represents the install command
@@ -79,10 +79,10 @@ Remarks:
 			}
 
 			if len(pluginNames) != 0 && *manifest != "" {
-				return errors.New("must specify either specify stdin or --manifest or args")
+				return errors.New("must specify either specify either plugin names (via positional arguments or STDIN), or --manifest; not both")
 			}
 
-			if *forceDownloadFile != "" && *manifest == "" {
+			if *archiveFileOverride != "" && *manifest == "" {
 				return errors.New("--archive can be specified only with --manifest")
 			}
 
@@ -106,24 +106,20 @@ Remarks:
 				install = append(install, plugin)
 			}
 
-			if len(install) > 1 && *manifest != "" {
-				return errors.New("can't use --manifest option with multiple plugins")
-			}
-
 			if len(install) == 0 {
 				return cmd.Help()
 			}
 
-			// Print plugin namesFromFile
 			for _, plugin := range install {
 				glog.V(2).Infof("Will install plugin: %s\n", plugin.Name)
 			}
 
 			var failed []string
-			// Do install
 			for _, plugin := range install {
 				fmt.Fprintf(os.Stderr, "Installing plugin: %s\n", plugin.Name)
-				err := installation.Install(paths, plugin, *forceDownloadFile)
+				err := installation.Install(paths, plugin, installation.InstallOpts{
+					ArchiveFileOverride: *archiveFileOverride,
+				})
 				if err == installation.ErrIsAlreadyInstalled {
 					glog.Warningf("Skipping plugin %q, it is already installed", plugin.Name)
 					continue
@@ -157,7 +153,7 @@ Remarks:
 	}
 
 	manifest = installCmd.Flags().String("manifest", "", "(Development-only) specify plugin manifest directly.")
-	forceDownloadFile = installCmd.Flags().String("archive", "", "(Development-only) force all downloads to use the specified file")
+	archiveFileOverride = installCmd.Flags().String("archive", "", "(Development-only) force all downloads to use the specified file")
 	noUpdateIndex = installCmd.Flags().Bool("no-update-index", false, "(Experimental) do not update local copy of plugin index before installing")
 
 	rootCmd.AddCommand(installCmd)

--- a/pkg/installation/util.go
+++ b/pkg/installation/util.go
@@ -21,28 +21,8 @@ import (
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/krew/pkg/constants"
-	"sigs.k8s.io/krew/pkg/index"
 	"sigs.k8s.io/krew/pkg/installation/receipt"
 )
-
-func getDownloadTarget(index index.Plugin) (version, sha256sum, uri string, fos []index.FileOperation, bin string, err error) {
-	// TODO(ahmetb): We have many return values from this method, indicating
-	// code smell. More specifically we return all-or-nothing, so ideally this
-	// should be converted into a struct, like InstallOperation{} contains all
-	// the data needed to install a plugin.
-	p, ok, err := GetMatchingPlatform(index.Spec.Platforms)
-	if err != nil {
-		return "", "", "", nil, p.Bin, errors.Wrap(err, "failed to get matching platforms")
-	}
-	if !ok {
-		return "", "", "", nil, p.Bin, errors.New("no matching platform found")
-	}
-	version = index.Spec.Version
-	uri = p.URI
-	sha256sum = p.Sha256
-	glog.V(4).Infof("found a matching platform, version=%s checksum=%s", version, sha256sum)
-	return version, sha256sum, uri, p.Files, p.Bin, nil
-}
 
 // ListInstalledPlugins returns a list of all install plugins in a
 // name:version format based on the install receipts at the specified dir.

--- a/pkg/installation/util_test.go
+++ b/pkg/installation/util_test.go
@@ -16,78 +16,8 @@ package installation
 
 import (
 	"path/filepath"
-	"reflect"
-	"runtime"
 	"testing"
-
-	"sigs.k8s.io/krew/pkg/index"
-	"sigs.k8s.io/krew/pkg/testutil"
 )
-
-func Test_getDownloadTarget(t *testing.T) {
-	tests := []struct {
-		name          string
-		plugin        index.Plugin
-		wantVersion   string
-		wantSHA256Sum string
-		wantURI       string
-		wantFos       []index.FileOperation
-		wantBin       string
-		wantErr       bool
-	}{
-		{
-			name: "matches to a platform in the list",
-			plugin: testutil.NewPlugin().
-				WithVersion("v1.0.1").WithPlatforms(
-				testutil.NewPlatform().WithOS("none").V(),
-				testutil.NewPlatform().WithBin("kubectl-foo").
-					WithOS(runtime.GOOS).
-					WithFiles([]index.FileOperation{{From: "a", To: "b"}}).
-					WithSHA256("f0f0f0").
-					WithURI("http://localhost").V()).V(),
-			wantVersion:   "v1.0.1",
-			wantSHA256Sum: "f0f0f0",
-			wantURI:       "http://localhost",
-			wantFos:       []index.FileOperation{{From: "a", To: "b"}},
-			wantBin:       "kubectl-foo",
-			wantErr:       false,
-		},
-		{
-			name: "does not match to a platform",
-			plugin: testutil.NewPlugin().
-				WithVersion("v1.0.1").
-				WithPlatforms(
-					testutil.NewPlatform().WithOS("foo").V(),
-					testutil.NewPlatform().WithOS("bar").V(),
-				).V(),
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotVersion, gotSHA256Sum, gotURI, gotFos, bin, err := getDownloadTarget(tt.plugin)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getDownloadTarget() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if gotVersion != tt.wantVersion {
-				t.Errorf("getDownloadTarget() gotVersion = %v, want %v", gotVersion, tt.wantVersion)
-			}
-			if gotSHA256Sum != tt.wantSHA256Sum {
-				t.Errorf("getDownloadTarget() gotSHA256Sum = %v, want %v", gotSHA256Sum, tt.wantSHA256Sum)
-			}
-			if bin != tt.wantBin {
-				t.Errorf("getDownloadTarget() bin = %v, want %v", bin, tt.wantBin)
-			}
-			if gotURI != tt.wantURI {
-				t.Errorf("getDownloadTarget() gotURI = %v, want %v", gotURI, tt.wantURI)
-			}
-			if !reflect.DeepEqual(gotFos, tt.wantFos) {
-				t.Errorf("getDownloadTarget() gotFos = %v, want %v", gotFos, tt.wantFos)
-			}
-		})
-	}
-}
 
 func testdataPath(t *testing.T) string {
 	pwd, err := filepath.Abs(".")


### PR DESCRIPTION
- `getDownloadTarget()`: removed, it didn't do anything interesting.
- `downloadAndMove()`:
    - renamed to `downloadAndExtract()` which better reflects the functionality
    - reduced methods from 7 to 4
    - refactored the "move" operation out of this method (decouples "move"
      from "download+extract") and we now call "move" from install().
    - added unit tests (both for downloading a file, and --archive override)

- introduced `installOperation` which contains the minimal information to
  perform installation operation.

- introduced `InstallOpts` type to scale out (in the future)

- `install()`:
    - accepts fewer arguments (2) than before (8)
    - no longer knows about index.Plugin, or environment.Paths

- cmd/install: removed a redundant check detecting specifying plugin names
  along with --manifest option.

Fixes #293
/kind cleanup
/assign @corneliusweig