### PR TITLE
integration_test: add more test cases

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -39,19 +39,17 @@ func init() {
 	installCmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install kubectl plugins",
-		Long: `Install a plugin.
-
-This command can be used to install one or multiple plugins.
+		Long: `Install one or multiple kubectl plugins.
 
 Examples:
   To install one or multiple plugins, run:
     kubectl krew install NAME [NAME...]
 
-  To install plugins from a file, run:
+  To install plugins from a newline-delimited file, run:
     kubectl krew install < file.txt
 
   (For developers) To provide a custom plugin manifest, use the --manifest
-  argument Similarly, instead of downloading files from a URL, you can specify a
+  argument. Similarly, instead of downloading files from a URL, you can specify a
   local --archive file:
 	kubectl krew install --manifest=FILE [--archive=FILE]
 

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -32,8 +32,8 @@ func init() {
 	// listCmd represents the list command
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List installed plugins",
-		Long: `Show a list of installed plugins and their versions.
+		Short: "List installed kubectl plugins",
+		Long: `Show a list of installed kubectl plugins and their versions.
 
 Remarks:
   Redirecting the output of this command to a program or file will only print

--- a/cmd/krew/cmd/system.go
+++ b/cmd/krew/cmd/system.go
@@ -33,7 +33,7 @@ This command will be removed without further notice from future versions of krew
 	Hidden: true,
 }
 
-// todo(corneliusweig) remove migration code with v0.4
+// TODO(corneliusweig) remove migration code with v0.4
 // systemCmd represents the system command
 var receiptsUpgradeCmd = &cobra.Command{
 	Use:   "receipts-upgrade",

--- a/hack/verify-receipts-upgrade-migration.sh
+++ b/hack/verify-receipts-upgrade-migration.sh
@@ -17,7 +17,7 @@
 # This script tests "krew system receipts-migration" which was introduced for
 # migrating krew 0.2.x to krew 0.3.x.
 #
-# TODO(ahmmetb,corneliusweig) remove at/after krew 0.4.x when receipts-migration
+# TODO(ahmetb,corneliusweig) remove at/after krew 0.4.x when receipts-migration
 # is no longer supported.
 
 set -euo pipefail

--- a/integration_test/help_test.go
+++ b/integration_test/help_test.go
@@ -22,5 +22,8 @@ func TestKrewHelp(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
+	test.Krew().RunOrFail() // no args
 	test.Krew("help").RunOrFail()
+	test.Krew("-h").RunOrFail()
+	test.Krew("--help").RunOrFail()
 }

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -49,8 +49,9 @@ func TestKrewInstallReRun(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithIndex().Krew("install", validPlugin).RunOrFail()
-	test.WithIndex().Krew("install", validPlugin).RunOrFail()
+	test = test.WithIndex()
+	test.Krew("install", validPlugin).RunOrFail()
+	test.Krew("install", validPlugin).RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
 }
 

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -16,6 +16,7 @@ package integrationtest
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/krew/pkg/constants"
@@ -27,12 +28,68 @@ const (
 
 func TestKrewInstall(t *testing.T) {
 	skipShort(t)
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	if err := test.Krew("install", validPlugin); err == nil {
+		t.Fatal("expected to fail without initializing the index")
+	}
+
+	test = test.WithIndex()
+	if err := test.Krew("install"); err == nil {
+		t.Fatal("expected failure without any args or stdin")
+	}
+
+	test.Krew("install", validPlugin).RunOrFailOutput()
+	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+}
+
+func TestKrewInstallReRun(t *testing.T) {
+	skipShort(t)
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithIndex().Krew("install", validPlugin).RunOrFail()
+	test.WithIndex().Krew("install", validPlugin).RunOrFail()
+	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+}
+
+func TestKrewInstall_MultiplePositionalArgs(t *testing.T) {
+	skipShort(t)
 
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithIndex().Krew("install", validPlugin).RunOrFailOutput()
+	test.WithIndex().Krew("install", validPlugin, validPlugin2).RunOrFailOutput()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+	test.AssertExecutableInPATH("kubectl-" + validPlugin2)
+}
+
+func TestKrewInstall_Stdin(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithIndex().WithStdin(strings.NewReader(validPlugin + "\n" + validPlugin2)).
+		Krew("install").RunOrFailOutput()
+
+	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+	test.AssertExecutableInPATH("kubectl-" + validPlugin2)
+}
+
+func TestKrewInstall_StdinAndPositionalArguments(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	// when stdin is detected, it's ignored in favor of positional arguments
+	test.WithIndex().
+		WithStdin(strings.NewReader(validPlugin2)).
+		Krew("install", validPlugin).RunOrFail()
+	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+	test.AssertExecutableNotInPATH("kubectl-" + validPlugin2)
 }
 
 func TestKrewInstall_Manifest(t *testing.T) {
@@ -60,7 +117,7 @@ func TestKrewInstall_ManifestAndArchive(t *testing.T) {
 	test.AssertExecutableInPATH("kubectl-" + fooPlugin)
 }
 
-func TestKrewInstall_OnlyArchiveFails(t *testing.T) {
+func TestKrewInstall_OnlyArchive(t *testing.T) {
 	skipShort(t)
 
 	test, cleanup := NewTest(t)
@@ -71,5 +128,20 @@ func TestKrewInstall_OnlyArchiveFails(t *testing.T) {
 		Run()
 	if err == nil {
 		t.Errorf("Expected install to fail but was successful")
+	}
+}
+
+func TestKrewInstall_PositionalArgumentsAndManifest(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	err := test.Krew("install", validPlugin,
+		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),
+		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
+		Run()
+	if err == nil {
+		t.Fatal("expected failure")
 	}
 }

--- a/integration_test/list_test.go
+++ b/integration_test/list_test.go
@@ -15,8 +15,9 @@
 package integrationtest
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestKrewList(t *testing.T) {
@@ -26,14 +27,18 @@ func TestKrewList(t *testing.T) {
 	defer cleanup()
 
 	initialList := test.WithIndex().Krew("list").RunOrFailOutput()
-	if bytes.Contains(initialList, []byte(validPlugin)) {
-		t.Errorf("%q should initially not be installed", validPlugin)
+	initialOut := []byte{'\n'}
+
+	if diff := cmp.Diff(initialList, initialOut); diff != "" {
+		t.Fatalf("expected empty output from 'list':\n%s", diff)
 	}
 
 	test.Krew("install", validPlugin).RunOrFail()
+	expected := []byte(validPlugin + "\n")
 
 	eventualList := test.Krew("list").RunOrFailOutput()
-	if !bytes.Contains(eventualList, []byte(validPlugin)) {
-		t.Errorf("%q should eventually be installed", validPlugin)
+	if diff := cmp.Diff(eventualList, expected); diff != "" {
+		t.Fatalf("'list' output doesn't match:\n%s", diff)
 	}
+	// TODO(ahmetb): install multiple plugins and see if the output is sorted
 }

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -22,9 +22,21 @@ func TestKrewUninstall(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithIndex().Krew("install", validPlugin).RunOrFailOutput()
+	test = test.WithIndex()
+
+	if err := test.Krew("uninstall").Run(); err == nil {
+		t.Fatal("expected failure without no arguments")
+	}
+	if err := test.Krew("uninstall", validPlugin).Run(); err == nil {
+		t.Fatal("expected failure deleting non-installed plugin")
+	}
+	test.Krew("install", validPlugin).RunOrFailOutput()
 	test.Krew("uninstall", validPlugin).RunOrFailOutput()
 	test.AssertExecutableNotInPATH("kubectl-" + validPlugin)
+
+	if err := test.Krew("uninstall", validPlugin).Run(); err == nil {
+		t.Fatal("expected failure for uninstalled plugin")
+	}
 }
 
 func TestKrewRemove_AliasSupported(t *testing.T) {

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -29,4 +29,8 @@ func TestKrewUpdate(t *testing.T) {
 		// the first line is the header
 		t.Errorf("Less than %d plugins found, `krew update` most likely failed unless TestKrewSearchAll also failed", len(plugins)-1)
 	}
+
+	if err := test.Krew("update").Run(); err != nil {
+		t.Fatal("re-run of 'update' must succeed")
+	}
 }

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -22,6 +22,14 @@ import (
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
+func TestKrewUpgrade_WithoutIndexInitialized(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+	test.Krew("upgrade").RunOrFailOutput()
+}
+
 func TestKrewUpgrade(t *testing.T) {
 	skipShort(t)
 


### PR DESCRIPTION
Added more tests or expanded existing tests to:

- cover args/stdin handling edge cases for `install` cmd
- cover status code of re-runs of `install`, `update`, and `remove`
- cover status when index not initialized in `remove`, `upgrade` and `install`
- several other minor adjustments

Fixes #294
Fixes #295