### PR TITLE
Validate plugins can be removed without local manifest

### DIFF
--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -68,7 +68,7 @@ func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 		t.Fatalf("could not read local manifest file at %s: %v", localManifest, err)
 	}
 	test.Krew("install", validPlugin).RunOrFail()
-	if err := os.RemoveAll(localManifest); err != nil {
+	if err := os.Remove(localManifest); err != nil {
 		t.Fatalf("failed to remove local manifest file: %v", err)
 	}
 	test.Krew("remove", validPlugin).RunOrFail()

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -70,7 +70,6 @@ func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 	test.Krew("install", validPlugin).RunOrFail()
 	if err := os.RemoveAll(localManifest); err != nil {
 		t.Fatalf("failed to remove local manifest file: %v", err)
-
 	}
-	test.Krew("remove", validPlugin)
+	test.Krew("remove", validPlugin).RunOrFail()
 }


### PR DESCRIPTION
This validates the scenario that we can remove/rename plugins in the index
without breaking local user installations (since this is now possible with
the install receipts).

/assign @corneliusweig