### PR TITLE
Forbid long lines in manifests during validation

### DIFF
--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -77,13 +77,13 @@ func validateManifestFile(path string) error {
 	}
 	glog.Infof("structural validation OK")
 
-	if maxLen := 80; maxLen < getMaxLinelength(p.Spec.Description) {
+	if maxLen := 80; !validateLineLength(p.Spec.Description, maxLen) {
 		glog.Warningf("line length in `description` exceeds %d characters", maxLen)
 	}
-	if maxLen := 70; maxLen < getMaxLinelength(p.Spec.ShortDescription) {
+	if maxLen := 70; !validateLineLength(p.Spec.ShortDescription, maxLen) {
 		glog.Warningf("line length in `shortDescription` exceeds %d characters", maxLen)
 	}
-	if maxLen := 80; maxLen < getMaxLinelength(p.Spec.Caveats) {
+	if maxLen := 80; !validateLineLength(p.Spec.Caveats, maxLen) {
 		glog.Warningf("line length in `caveats` exceeds %d characters", maxLen)
 	}
 
@@ -208,12 +208,16 @@ func allPlatforms() [][2]string {
 	}
 }
 
-func getMaxLinelength(s string) int {
-	max := 0
+// validateLineLength checks if the maximum line length is below maxLen.
+// Lines may exceed this limit, if they are just one word, i.e. without spaces.
+func validateLineLength(s string, maxLen int) bool {
 	for _, line := range strings.Split(s, "\n") {
-		if l := len(line); max < l {
-			max = l
+		if len(line) <= maxLen {
+			continue
+		}
+		if strings.Contains(strings.TrimSpace(line), " ") {
+			return false
 		}
 	}
-	return max
+	return true
 }

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,9 +216,18 @@ func validateLineLength(s string, maxLen int) bool {
 		if len(line) <= maxLen {
 			continue
 		}
-		if strings.Contains(strings.TrimSpace(line), " ") {
+		if !containsURI(line) {
 			return false
 		}
 	}
 	return true
+}
+
+func containsURI(line string) bool {
+	for _, word := range strings.Fields(line) {
+		if _, err := url.ParseRequestURI(word); err == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -78,13 +78,13 @@ func validateManifestFile(path string) error {
 	glog.Infof("structural validation OK")
 
 	if maxLen := 80; !validateLineLength(p.Spec.Description, maxLen) {
-		glog.Warningf("line length in `description` exceeds %d characters", maxLen)
+		return fmt.Errorf("line length in `description` exceeds %d characters", maxLen)
 	}
 	if maxLen := 70; !validateLineLength(p.Spec.ShortDescription, maxLen) {
-		glog.Warningf("line length in `shortDescription` exceeds %d characters", maxLen)
+		return fmt.Errorf("line length in `shortDescription` exceeds %d characters", maxLen)
 	}
 	if maxLen := 80; !validateLineLength(p.Spec.Caveats, maxLen) {
-		glog.Warningf("line length in `caveats` exceeds %d characters", maxLen)
+		return fmt.Errorf("line length in `caveats` exceeds %d characters", maxLen)
 	}
 
 	// make sure each platform matches a supported platform

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -77,6 +77,16 @@ func validateManifestFile(path string) error {
 	}
 	glog.Infof("structural validation OK")
 
+	if maxLen := 80; maxLen < getMaxLinelength(p.Spec.Description) {
+		glog.Warningf("line length in `description` exceeds %d characters", maxLen)
+	}
+	if maxLen := 70; maxLen < getMaxLinelength(p.Spec.ShortDescription) {
+		glog.Warningf("line length in `shortDescription` exceeds %d characters", maxLen)
+	}
+	if maxLen := 80; maxLen < getMaxLinelength(p.Spec.Caveats) {
+		glog.Warningf("line length in `caveats` exceeds %d characters", maxLen)
+	}
+
 	// make sure each platform matches a supported platform
 	for i, p := range p.Spec.Platforms {
 		if os, arch := findAnyMatchingPlatform(p.Selector); os == "" || arch == "" {
@@ -196,4 +206,14 @@ func allPlatforms() [][2]string {
 		{"darwin", "386"},
 		{"darwin", "amd64"},
 	}
+}
+
+func getMaxLinelength(s string) int {
+	max := 0
+	for _, line := range strings.Split(s, "\n") {
+		if l := len(line); max < l {
+			max = l
+		}
+	}
+	return max
 }

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -212,16 +212,16 @@ line below limit
 			expected: false,
 		},
 		{
-			name: "single word above length limit",
+			name: "long line with a URL",
 			input: "	https://krew.dev/is_really_awesome   ",
 			expected: true,
 		},
 		{
-			name: "multiple lines with single word above length limit",
+			name: "multiple lines with long line containing a URL",
 			input: `
 line below limit
 line below limit
-https://krew.dev/is_really_awesome
+This is a long line with a URL https://krew.dev/is_really_awesome
 line below limit
 line below limit
 `,

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -183,3 +183,58 @@ func Test_isOverlappingPlatformSelectors_overlap(t *testing.T) {
 		t.Fatal("expected overlap")
 	}
 }
+
+func Test_validateLineLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "single line below limit",
+			input:    "short string",
+			expected: true,
+		},
+		{
+			name:     "single line above limit",
+			input:    "long string long string long string",
+			expected: false,
+		},
+		{
+			name: "multiple lines, one too long",
+			input: `
+line below limit
+line below limit
+long string long string long string
+line below limit
+line below limit
+`,
+			expected: false,
+		},
+		{
+			name: "single word above length limit",
+			input: "	https://krew.dev/is_really_awesome   ",
+			expected: true,
+		},
+		{
+			name: "multiple lines with single word above length limit",
+			input: `
+line below limit
+line below limit
+https://krew.dev/is_really_awesome
+line below limit
+line below limit
+`,
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := validateLineLength(test.input, 20)
+			if actual != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -193,28 +193,27 @@ func Test_validateLineLength(t *testing.T) {
 		{
 			name:     "single line below limit",
 			input:    "short string",
-			expected: true,
+			expected: false,
+		},
+		{
+			name:     "single line with UTF characters",
+			input:    "\u1f98\u1f97\u1f96\u1f95\u1f94\u1f93\u1f92\u1f91\u1f90\u1f89\u1f88\u1f78\u1f68\u1f58\u1f38\u1f18",
+			expected: false,
 		},
 		{
 			name:     "single line above limit",
 			input:    "long string long string long string",
-			expected: false,
+			expected: true,
 		},
 		{
-			name: "multiple lines, one too long",
-			input: `
-line below limit
-line below limit
-long string long string long string
-line below limit
-line below limit
-`,
-			expected: false,
+			name:     "multiple lines, one too long",
+			input:    "line below limit\nline below limit\nlong string long string long string\rline below limit\rline below limit",
+			expected: true,
 		},
 		{
 			name: "long line with a URL",
 			input: "	https://krew.dev/is_really_awesome   ",
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "multiple lines with long line containing a URL",
@@ -225,13 +224,13 @@ This is a long line with a URL https://krew.dev/is_really_awesome
 line below limit
 line below limit
 `,
-			expected: true,
+			expected: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := validateLineLength(test.input, 20)
+			actual := isLineLengthInvalid(test.input, 16)
 			if actual != test.expected {
 				t.Errorf("expected %v, got %v", test.expected, actual)
 			}


### PR DESCRIPTION
This PR adds checks for small line lengths in manifest text blocks. This is desired for proper formatting on small screens.

I opted against hard checks, because there are good reasons to sometimes neglect the length limitation. For example, long URLs.

Close #298