### PR TITLE
pkg/download: close files after extracting in tar

### DIFF
--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -72,6 +72,7 @@ func extractZIP(targetDir string, read io.ReaderAt, size int64) error {
 
 		dst, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
 		if err != nil {
+			src.Close()
 			return errors.Wrap(err, "can't create file in zip destination dir")
 		}
 		close := func() {

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -101,7 +101,9 @@ func install(op installOperation, opts InstallOpts) error {
 	}
 	defer func() {
 		glog.V(3).Infof("Deleting the download staging directory %s", op.downloadStagingDir)
-		_ = os.RemoveAll(op.downloadStagingDir)
+		if err := os.RemoveAll(op.downloadStagingDir); err != nil {
+			glog.Warningf("failed to clean up download staging directory: %s", err)
+		}
 	}()
 	if err := downloadAndExtract(op.downloadStagingDir, op.platform.URI, op.platform.Sha256, opts.ArchiveFileOverride); err != nil {
 		return errors.Wrap(err, "failed to download and extract")


### PR DESCRIPTION
- Close file handle after extracting files on windows in extractTARGZ().
- Also ensure we close when io.Copy fails on extractZIP().
- Log the ignored error from the cleanup of DownloadPath.

Fixes #308.