### PR TITLE
prevent erroring with empty plugin name

### DIFF
--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -58,7 +58,7 @@ kubectl krew upgrade foo bar"`,
 			for _, name := range pluginNames {
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
-					return errors.Wrapf(err, "failed to load the index file for plugin %s", plugin.Name)
+					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}
 
 				glog.V(2).Infof("Upgrading plugin: %s\n", plugin.Name)


### PR DESCRIPTION
When loading plugin manifest fails, we create an error with
plugin.Name, but plugin instance is an empty struct, so .Name is
empty string.

/assign @corneliusweig