### PR TITLE
lint: enable deadcode and varcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,5 +31,7 @@ linters:
     - staticcheck
     - structcheck
     - prealloc
+    - deadcode
+    - varcheck
   disable:
     - errcheck


### PR DESCRIPTION
related to #292

didn't enable `tests: true` since they are included by [default](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml#L16)