### PR TITLE
Correct import order

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/krew/pkg/index"
 	"sigs.k8s.io/krew/pkg/index/indexscanner"
 	"sigs.k8s.io/krew/pkg/index/validation"
 	"sigs.k8s.io/krew/pkg/installation"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 func init() {

--- a/cmd/krew/cmd/system.go
+++ b/cmd/krew/cmd/system.go
@@ -15,9 +15,9 @@
 package cmd
 
 import (
-	"sigs.k8s.io/krew/pkg/receiptsmigration"
-
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/krew/pkg/receiptsmigration"
 )
 
 // todo(corneliusweig) remove migration code with v0.4

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"os"
 
-	"sigs.k8s.io/krew/pkg/index/indexscanner"
-	"sigs.k8s.io/krew/pkg/installation"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/krew/pkg/index/indexscanner"
+	"sigs.k8s.io/krew/pkg/installation"
 )
 
 func init() {

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -21,11 +21,11 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"sigs.k8s.io/krew/pkg/index"
-	"sigs.k8s.io/krew/pkg/pathutil"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
+	"sigs.k8s.io/krew/pkg/index"
+	"sigs.k8s.io/krew/pkg/pathutil"
 )
 
 type move struct {


### PR DESCRIPTION
https://github.com/kubernetes-sigs/krew/blob/master/.golangci.yml#L6 wasn't applied correctly. 

This PR fixes existing issues but the root cause is still there. Since golangci-lint won't be fixed soon. I suggest integrating [impi](https://github.com/pavius/impi) in the short run (as a follow up PR or update on this)