### PR TITLE
docs: Add link to GitHub template repo to developer guide

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -31,6 +31,11 @@ Before creating a plugin, read the [Kubernetes Plugins documentation][plugins].
 designed to provide the same command-line arguments, kubeconfig parser,
 Kubernetes API REST client, and printing logic.
 
+**Quick start for Go:** For Go plugins, there's a 
+[GitHub template repo](https://github.com/replicatedhq/krew-plugin-template) 
+that implements these best practices and also configures GoReleaser and a 
+GitHub Action to create releases when a tag is pushed.
+
 Below you will create a small plugin named `foo` which prints the environment
 variables to the screen and exits.
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -31,10 +31,11 @@ Before creating a plugin, read the [Kubernetes Plugins documentation][plugins].
 designed to provide the same command-line arguments, kubeconfig parser,
 Kubernetes API REST client, and printing logic.
 
-**Quick start for Go:** For Go plugins, there's a 
-[GitHub template repo](https://github.com/replicatedhq/krew-plugin-template) 
-that implements these best practices and also configures GoReleaser and a 
-GitHub Action to create releases when a tag is pushed.
+**Unofficial Quickstart for Go:** For Go plugins, there's a
+[GitHub template repo](https://github.com/replicatedhq/krew-plugin-template)
+that implements these best practices and also configures GoReleaser and a
+GitHub Action to create releases when a tag is pushed. Note: this template
+repo is not maintained by the Krew project.
 
 Below you will create a small plugin named `foo` which prints the environment
 variables to the screen and exits.
@@ -197,10 +198,10 @@ wildcard may install more files than desired.
   ```yaml
       files: [{from: "*", to: "."}]
   ```
-  
+
   This copies out binaries for both platforms to the installation directory
   onto the user’s machine, despite only one of them will be used:
-  
+
   ```text
   .
   └── krew-foo-windows.exe
@@ -253,7 +254,7 @@ plugin name.
 #### Specifying a plugin download URL
 
 krew plugins must be packaged as `.zip` or `.tar.gz` archives and should be made
-available for download publicly. 
+available for download publicly.
 Downloading from a URL also requires a checksum of the downloaded content:
 
 - `uri`: URL to the archive file (`.zip` or `.tar.gz`)


### PR DESCRIPTION
Adding a link to a GitHub template repo for Go projects creating krew plugins. This template has some of the best practices referenced in the guide implemented. The template also has GoReleaser configured to create a release on tag, a basic krew plugin.yaml, and all of the latest k8s client-go dependencies added and configured.

If there's a better place or wording for this, I'm happy to move/change it.