### PR TITLE
lint: enable errcheck and fix some issues

### DIFF
--- a/.errcheck-excluded.txt
+++ b/.errcheck-excluded.txt
@@ -1,0 +1,2 @@
+os.MkdirAll
+io.Copy

--- a/.errcheck-excluded.txt
+++ b/.errcheck-excluded.txt
@@ -1,2 +1,0 @@
-os.MkdirAll
-io.Copy

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,11 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: sigs.k8s.io/krew
+  errcheck:
+    check-type-assertions: false
+    check-blank: false
+    exclude: .errcheck-excluded.txt
+
 
 # options for analysis running
 run:
@@ -36,5 +41,4 @@ linters:
     - prealloc
     - deadcode
     - varcheck
-  disable:
     - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,6 @@ linters-settings:
   errcheck:
     check-type-assertions: false
     check-blank: false
-    exclude: .errcheck-excluded.txt
-
 
 # options for analysis running
 run:

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -68,9 +68,9 @@ func init() {
 			pflag.Lookup(f.Name).Hidden = true
 		}
 	})
-	// Set glog default to stderr
 	if err := flag.Set("logtostderr", "true"); err != nil {
-		glog.Fatal(err)
+		fmt.Printf("can't set log to stderr %+v", err)
+		os.Exit(1)
 	}
 
 	paths = environment.MustGetKrewPaths()

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -62,13 +62,16 @@ func Execute() {
 
 func init() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	flag.CommandLine.Parse([]string{}) // convince pkg/flag we parsed the flags
+	_ = flag.CommandLine.Parse([]string{}) // convince pkg/flag we parsed the flags
 	flag.CommandLine.VisitAll(func(f *flag.Flag) {
 		if f.Name != "v" { // hide all glog flags except for -v
 			pflag.Lookup(f.Name).Hidden = true
 		}
 	})
-	flag.Set("logtostderr", "true") // Set glog default to stderr
+	// Set glog default to stderr
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		glog.Fatal(err)
+	}
 
 	paths = environment.MustGetKrewPaths()
 	if err := ensureDirs(paths.BasePath(),

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -40,9 +40,9 @@ var flManifest string
 
 func init() {
 	flag.StringVar(&flManifest, "manifest", "", "path to plugin manifest file")
-	// Set glog default to stderr
 	if err := flag.Set("logtostderr", "true"); err != nil {
-		glog.Fatal(err)
+		fmt.Printf("can't set log to stderr %+v", err)
+		os.Exit(1)
 	}
 	// TODO(ahmetb) iterate over glog flags and hide them (not sure if possible without using pflag)
 	flag.Parse()

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -40,7 +40,10 @@ var flManifest string
 
 func init() {
 	flag.StringVar(&flManifest, "manifest", "", "path to plugin manifest file")
-	flag.Set("logtostderr", "true") // Set glog default to stderr
+	// Set glog default to stderr
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		glog.Fatal(err)
+	}
 	// TODO(ahmetb) iterate over glog flags and hide them (not sure if possible without using pflag)
 	flag.Parse()
 }

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -257,7 +257,9 @@ func (it *ITest) initializeIndex() {
 			it.t.Fatalf("cannot clone repository: %s", err)
 		}
 
-		ioutil.WriteFile(persistentCacheFile, indexTar, 0600)
+		if err = ioutil.WriteFile(persistentCacheFile, indexTar, 0600); err != nil {
+			it.t.Fatalf("cannot write persistent cache file: %s", err)
+		}
 	})
 
 	indexDir := filepath.Join(it.Root(), "index")

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -61,7 +61,9 @@ func extractZIP(targetDir string, read io.ReaderAt, size int64) error {
 	for _, f := range zipReader.File {
 		path := filepath.Join(targetDir, filepath.FromSlash(f.Name))
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(path, f.Mode())
+			if err := os.MkdirAll(path, f.Mode()); err != nil {
+				return errors.Wrap(err, "can't create directory tree")
+			}
 			continue
 		}
 

--- a/pkg/download/verifier_test.go
+++ b/pkg/download/verifier_test.go
@@ -50,7 +50,7 @@ func TestSha256Verifier(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := NewSha256Verifier(tt.args.hash)
-			io.Copy(v, bytes.NewReader(tt.write))
+			_, _ = io.Copy(v, bytes.NewReader(tt.write))
 			if err := v.Verify(); (err != nil) != tt.wantError {
 				t.Errorf("NewSha256Verifier().Write(%x).Verify() = %v, wantReader %v", tt.write, err, tt.wantError)
 				return
@@ -84,7 +84,7 @@ func TestTrueVerifier(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := NewInsecureVerifier()
-			io.Copy(v, bytes.NewReader(tt.write))
+			_, _ = io.Copy(v, bytes.NewReader(tt.write))
 			if err := v.Verify(); (err != nil) != tt.wantError {
 				t.Errorf("NewInsecureVerifier().Write(%x).Verify() = %v, wantReader %v", tt.write, err, tt.wantError)
 				return

--- a/pkg/receiptsmigration/migration_test.go
+++ b/pkg/receiptsmigration/migration_test.go
@@ -68,8 +68,8 @@ func TestIsMigrated(t *testing.T) {
 
 			newPaths := environment.MustGetKrewPaths()
 
-			os.MkdirAll(tmpDir.Path("receipts"), os.ModePerm)
-			os.MkdirAll(tmpDir.Path("store"), os.ModePerm)
+			_ = os.MkdirAll(tmpDir.Path("receipts"), os.ModePerm)
+			_ = os.MkdirAll(tmpDir.Path("store"), os.ModePerm)
 			for _, name := range test.filesPresent {
 				touch(tmpDir, name)
 			}


### PR DESCRIPTION
* add `.errcheck-excluded.txt` to disable some function calls as an example
* fixes #325