### PR TITLE
lint: bump golangci-lint to 1.18

### DIFF
--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -23,7 +23,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
   echo >&2 'Installing golangci-lint'
   curl --silent --fail --location \
-    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.17.1
+    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.18.0
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
bump golangci-lint to 1.18, various improvement and go 1.13

related #334 