### PR TITLE
Remove krew.zip from release, add krew.exe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ deploy:
   on:
     tags: true
   file:
+  - out/krew.yaml
   - out/krew.tar.gz
   - out/krew.tar.gz.sha256
-  - out/krew.zip
-  - out/krew.zip.sha256
-  - out/krew.yaml
+  - out/krew.exe
+  - out/krew.exe.sha256
   api_key:
     secure: t4a69ruCl15etso89c/GSone/gEvWnG6+w4q6NUhjViVaJJuIFDth1C1KxuF/wWW9r2R6zpGNj1uEhfXlc1VB1gGJnq/dkxW7iiVpjPFZUpBYJlK49esrytTGmlNuoKSlX4WTyXEgyH/zui8psJdeVhdDu4yCDrWdkb54gjyp7enluvPNxD40naGybeCNUfWLHvbCOQU4zPQIS2E2Sb7IPlup4LfcUDZYoGuGiBxN9nbU4GOk5gYB1jcQ2j2bDdWtEqp0T19auyWtv/gkU7Mn6Ebt+PG3OxBuyVbw2rq0eB7SeR/6lSrkj2TX4jiMsStNRE+W7Es3t+b8BSOLJcXfi7GA2iyDA70vZYS97bo8TCnezKr65O39ADtmgjVAx+eGOUhuOJj3d1Ft6yK7EILaYMq9zy90EyeMTcuqekFSUo8b1dnyP3fgkDyEyZ0YUiTlUUDkjJO+m+kMqoGH4FpkTgD+JmsXNTBzJ9PpRhP6d/Ti8OuwtjT7iEGmgp5aqPTti01vcxDK7xremNx5Vbqd7QHwFvOcJFPD9oF7rEMbFLpGfn61YHqefGnAxAItLmAOeMAH8A1j5xByB/4NsCukKJSJc3is0ClGL/d44BmeVtVrCM6/0lsCSOfyC5ph2f8o/yyC/26ShFsDyN6vB57VWTzXbUm3ybaT3GgRFTyC+Q=

--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ Check out the list of [kubectl plugins available on krew][list] or just run
 **Windows:**
 
 1. Make sure `git` is installed on your system.
-1. Download `krew.zip` and `krew.yaml` from the [Releases][releases] page.
-1. Extract the `krew.zip` archive to a directory, navigate to the directory.
-1. Launch a command-line window (`cmd.exe`) in that directory.
+1. Download `krew.exe` and `krew.yaml` from the [Releases][releases] page to
+   a directory.
+1. Launch a command-line window (`cmd.exe`) and navigate to that directory.
 1. Run the following command to install krew (pass the correct
    paths to `krew.yaml` and `krew.zip` below):
 
-       .\krew-windows_amd64.exe install --manifest=krew.yaml --archive=krew.zip
+       krew install --manifest=krew.yaml
 
-1. Add `%USERPROFILE%\.krew\bin` to your `PATH` environment variable
+1. Add `%USERPROFILE%\.krew\bin` directory to your `PATH` environment variable
    ([how?](https://java.com/en/download/help/path.xml))
 
 [releases]: https://github.com/kubernetes-sigs/krew/releases

--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -64,8 +64,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.zip
-    sha256: KREW_ZIP_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
+    sha256: KREW_TAR_CHECKSUM
     bin: krew.exe
     files:
     - from: ./krew-windows_amd64.exe

--- a/hack/make-release-notes.sh
+++ b/hack/make-release-notes.sh
@@ -29,8 +29,8 @@ download_base="https://github.com/kubernetes-sigs/krew/releases/download"
 download_assets=(
   krew.tar.gz
   krew.tar.gz.sha256
-  krew.zip
-  krew.zip.sha256
+  krew.exe
+  krew.exe.sha256
   krew.yaml
 )
 


### PR DESCRIPTION
This patch removes krew.zip (previously used in krew.yaml as well as
windows installation instructions) and adds:

- krew.exe (to be used in first-time installation on windows)
- krew.exe.sha256 (checksum file)

ref: #338 
/hold