### PR TITLE
Minor fixes for the release

### DIFF
--- a/docs/RELEASING_KREW.md
+++ b/docs/RELEASING_KREW.md
@@ -18,7 +18,7 @@
     KREW_ROOT="$(mktemp -d)" KREW_OS=linux \
         $krew install --manifest=out/krew.yaml --archive=out/krew.tar.gz && \
     KREW_ROOT="$(mktemp -d)" KREW_OS=windows \
-        $krew install --manifest=out/krew.yaml --archive=out/krew.zip
+        $krew install --manifest=out/krew.yaml --archive=out/krew.tar.gz
     ```
 
 ### Release a new version

--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -18,6 +18,7 @@ metadata:
   name: krew
 spec:
   version: "KREW_TAG"
+  homepage: https://sigs.k8s.io/krew
   shortDescription: Package manager for kubectl plugins.
   caveats: |
     krew is now installed! To start using kubectl plugins, you need to add
@@ -30,8 +31,12 @@ spec:
 
       * Windows: Add %USERPROFILE%\.krew\bin to your PATH environment variable
 
-    Run "kubectl krew" to list krew commands and get help.
-    You can find documentation at https://github.com/kubernetes-sigs/krew.
+    To list krew commands and to get help, run:
+      $ kubectl krew
+    For a full list of available plugins, run:
+      $ kubectl krew search
+
+    You can find documentation at https://sigs.k8s.io/krew.
 
   platforms:
   - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz

--- a/hack/make-binaries.sh
+++ b/hack/make-binaries.sh
@@ -37,7 +37,7 @@ git_rev="${SHORT_SHA:-$(git rev-parse --short HEAD)}"
 git_tag="${TAG_NAME:-$(git describe --tags --dirty --always)}"
 echo >&2 "(Stamping with git tag=${git_tag} rev=${git_rev})"
 
-env CGO_ENABLED=0 gox -osarch="${OSARCH:-$supported_platforms}" \
+env GO111MODULE=on CGO_ENABLED=0 gox -osarch="${OSARCH:-$supported_platforms}" \
   -tags netgo \
   -mod readonly \
   -ldflags="-w -X ${version_pkg}.gitCommit=${git_rev} \


### PR DESCRIPTION
- use tar.gz for installation smoke test on windows
- align manifest template with krew-index
- explicitly enable go modules when building the binaries