### PR TITLE
RELEASING_KREW: push only the release tag

### DIFF
--- a/docs/RELEASING_KREW.md
+++ b/docs/RELEASING_KREW.md
@@ -58,7 +58,7 @@ Krew tags versions starting with `v`. Example: `v0.2.0-rc.1`.
 
 1. **Push the tag:**
 
-       git push --tags
+       git push "${TAG:?TAG required}"
 
 1. **Verify on Releases tab on GitHub**
 


### PR DESCRIPTION
In the past this has caused other tags that aren't meant to be published to
be made public.

/assign @corneliusweig