### PR TITLE
Rely on standard utils for `IsSubPath`

### DIFF
--- a/pkg/pathutil/pathutil.go
+++ b/pkg/pathutil/pathutil.go
@@ -23,23 +23,15 @@ import (
 
 // IsSubPath checks if the extending path is an extension of the basePath, it will return the extending path
 // elements. Both paths have to be absolute or have the same root directory. The remaining path elements
-func IsSubPath(subPath, path string) ([]string, bool) {
-	basePieces := strings.Split(filepath.Clean(subPath), string(filepath.Separator))
-	extendingPieces := strings.Split(filepath.Clean(path), string(filepath.Separator))
-
-	// the binary has to be in the install path.
-	if len(basePieces) > len(extendingPieces) {
-		return nil, false
+func IsSubPath(basePath, subPath string) (string, bool) {
+	extendingPath, err := filepath.Rel(basePath, subPath)
+	if err != nil {
+		return "", false
 	}
-
-	// Compare path pieces.
-	for i, p := range basePieces {
-		if extendingPieces[i] != p {
-			return nil, false
-		}
+	if strings.HasPrefix(extendingPath, "..") {
+		return "", false
 	}
-
-	return extendingPieces[len(basePieces):], true
+	return extendingPath, true
 }
 
 // ReplaceBase will return a replacement path with replacement as a base of the path instead of the old base. a/b/c, a, d -> d/b/c
@@ -48,5 +40,5 @@ func ReplaceBase(path, old, replacement string) (string, error) {
 	if !ok {
 		return "", errors.Errorf("can't replace %q in %q, it is not a subpath", old, path)
 	}
-	return filepath.Join(replacement, filepath.Join(extendingPath...)), nil
+	return filepath.Join(replacement, extendingPath), nil
 }

--- a/pkg/pathutil/pathutil_test.go
+++ b/pkg/pathutil/pathutil_test.go
@@ -15,6 +15,7 @@
 package pathutil
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -28,7 +29,7 @@ func TestIsSubPathExtending(t *testing.T) {
 	tests := []struct {
 		name            string
 		args            args
-		wantExtending   []string
+		wantExtending   string
 		wantIsExtending bool
 	}{
 		{
@@ -37,7 +38,7 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a", "b"),
 				extendingPath: filepath.Join("a", "b", "c"),
 			},
-			wantExtending:   []string{"c"},
+			wantExtending:   "c",
 			wantIsExtending: true,
 		},
 		{
@@ -46,7 +47,7 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a", "b", "c"),
 				extendingPath: filepath.Join("a", "b", "c"),
 			},
-			wantExtending:   []string{},
+			wantExtending:   ".",
 			wantIsExtending: true,
 		},
 		{
@@ -55,7 +56,7 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a", "b"),
 				extendingPath: filepath.Join("a", "a", "c"),
 			},
-			wantExtending:   nil,
+			wantExtending:   "",
 			wantIsExtending: false,
 		},
 		{
@@ -64,8 +65,53 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a", "b"),
 				extendingPath: filepath.Join("a"),
 			},
-			wantExtending:   nil,
+			wantExtending:   "",
 			wantIsExtending: false,
+		},
+		{
+			name: "base path is not clean",
+			args: args{
+				basePath:      filepath.Join("d", "..", "a", "b", "..", "..", "a"),
+				extendingPath: filepath.Join("a", "b"),
+			},
+			wantExtending:   "b",
+			wantIsExtending: true,
+		},
+		{
+			name: "extending path is not clean",
+			args: args{
+				basePath:      filepath.Join("a"),
+				extendingPath: filepath.Join("d", "..", "a", "b", "c", ".."),
+			},
+			wantExtending:   "b",
+			wantIsExtending: true,
+		},
+		{
+			name: "base path is absolute",
+			args: args{
+				basePath:      filepath.Join(string(os.PathSeparator), "a"),
+				extendingPath: filepath.Join("a", "b"),
+			},
+			wantExtending:   "",
+			wantIsExtending: false,
+		},
+		{
+			name: "extending path is absolute",
+			args: args{
+				basePath:      filepath.Join("a"),
+				extendingPath: filepath.Join(string(os.PathSeparator), "a", "b"),
+			},
+			wantExtending:   "",
+			wantIsExtending: false,
+		},
+		{
+			name: "both paths are absolute",
+			args: args{
+				basePath:      filepath.Join(string(os.PathSeparator), "a"),
+				extendingPath: filepath.Join(string(os.PathSeparator), "a", "b"),
+			},
+			wantExtending:   "b",
+			wantIsExtending: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/pathutil/pathutil_test.go
+++ b/pkg/pathutil/pathutil_test.go
@@ -56,8 +56,6 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a", "b"),
 				extendingPath: filepath.Join("a", "a", "c"),
 			},
-			wantExtending:   "",
-			wantIsExtending: false,
 		},
 		{
 			name: "is not smaller extending",
@@ -65,8 +63,6 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a", "b"),
 				extendingPath: filepath.Join("a"),
 			},
-			wantExtending:   "",
-			wantIsExtending: false,
 		},
 		{
 			name: "base path is not clean",
@@ -92,8 +88,6 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join(string(os.PathSeparator), "a"),
 				extendingPath: filepath.Join("a", "b"),
 			},
-			wantExtending:   "",
-			wantIsExtending: false,
 		},
 		{
 			name: "extending path is absolute",
@@ -101,8 +95,6 @@ func TestIsSubPathExtending(t *testing.T) {
 				basePath:      filepath.Join("a"),
 				extendingPath: filepath.Join(string(os.PathSeparator), "a", "b"),
 			},
-			wantExtending:   "",
-			wantIsExtending: false,
 		},
 		{
 			name: "both paths are absolute",

--- a/pkg/pathutil/pathutil_test.go
+++ b/pkg/pathutil/pathutil_test.go
@@ -15,7 +15,6 @@
 package pathutil
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -35,8 +34,8 @@ func TestIsSubPathExtending(t *testing.T) {
 		{
 			name: "is extending",
 			args: args{
-				basePath:      filepath.Join("a", "b"),
-				extendingPath: filepath.Join("a", "b", "c"),
+				basePath:      filepath.FromSlash("a/b"),
+				extendingPath: filepath.FromSlash("a/b/c"),
 			},
 			wantExtending:   "c",
 			wantIsExtending: true,
@@ -44,8 +43,8 @@ func TestIsSubPathExtending(t *testing.T) {
 		{
 			name: "is extending same length",
 			args: args{
-				basePath:      filepath.Join("a", "b", "c"),
-				extendingPath: filepath.Join("a", "b", "c"),
+				basePath:      filepath.FromSlash("a/b/c"),
+				extendingPath: filepath.FromSlash("a/b/c"),
 			},
 			wantExtending:   ".",
 			wantIsExtending: true,
@@ -53,22 +52,22 @@ func TestIsSubPathExtending(t *testing.T) {
 		{
 			name: "is not extending",
 			args: args{
-				basePath:      filepath.Join("a", "b"),
-				extendingPath: filepath.Join("a", "a", "c"),
+				basePath:      filepath.FromSlash("a/b"),
+				extendingPath: filepath.FromSlash("a/a/c"),
 			},
 		},
 		{
 			name: "is not smaller extending",
 			args: args{
-				basePath:      filepath.Join("a", "b"),
-				extendingPath: filepath.Join("a"),
+				basePath:      filepath.FromSlash("a/b"),
+				extendingPath: filepath.FromSlash("a"),
 			},
 		},
 		{
 			name: "base path is not clean",
 			args: args{
-				basePath:      filepath.Join("d", "..", "a", "b", "..", "..", "a"),
-				extendingPath: filepath.Join("a", "b"),
+				basePath:      filepath.FromSlash("d/../a/b/../../a"),
+				extendingPath: filepath.FromSlash("a/b"),
 			},
 			wantExtending:   "b",
 			wantIsExtending: true,
@@ -76,8 +75,8 @@ func TestIsSubPathExtending(t *testing.T) {
 		{
 			name: "extending path is not clean",
 			args: args{
-				basePath:      filepath.Join("a"),
-				extendingPath: filepath.Join("d", "..", "a", "b", "c", ".."),
+				basePath:      filepath.FromSlash("a"),
+				extendingPath: filepath.FromSlash("d/../a/b/c/.."),
 			},
 			wantExtending:   "b",
 			wantIsExtending: true,
@@ -85,22 +84,22 @@ func TestIsSubPathExtending(t *testing.T) {
 		{
 			name: "base path is absolute",
 			args: args{
-				basePath:      filepath.Join(string(os.PathSeparator), "a"),
-				extendingPath: filepath.Join("a", "b"),
+				basePath:      filepath.FromSlash("/a"),
+				extendingPath: filepath.FromSlash("a/b"),
 			},
 		},
 		{
 			name: "extending path is absolute",
 			args: args{
-				basePath:      filepath.Join("a"),
-				extendingPath: filepath.Join(string(os.PathSeparator), "a", "b"),
+				basePath:      filepath.FromSlash("a"),
+				extendingPath: filepath.FromSlash("/a/b"),
 			},
 		},
 		{
 			name: "both paths are absolute",
 			args: args{
-				basePath:      filepath.Join(string(os.PathSeparator), "a"),
-				extendingPath: filepath.Join(string(os.PathSeparator), "a", "b"),
+				basePath:      filepath.FromSlash("/a"),
+				extendingPath: filepath.FromSlash("/a/b"),
 			},
 			wantExtending:   "b",
 			wantIsExtending: true,


### PR DESCRIPTION
* Add more test cases
* Fix misleading argument naming of `IsSubPath`
       - subPath -> basePath
       - path    -> subPath