### PR TITLE
RELEASING_KREW: Specify the repository to push the tag to

### DIFF
--- a/docs/RELEASING_KREW.md
+++ b/docs/RELEASING_KREW.md
@@ -58,7 +58,7 @@ Krew tags versions starting with `v`. Example: `v0.2.0-rc.1`.
 
 1. **Push the tag:**
 
-       git push "${TAG:?TAG required}"
+       git push origin "${TAG:?TAG required}"
 
 1. **Verify on Releases tab on GitHub**
 


### PR DESCRIPTION
When pushing individual tags, specifying the repos is mandatory.

I also wasn't aware of this when reviewing #369 :face_with_head_bandage:

/assign @ahmetb 