### PR TITLE
Use renameOrCopy for single-file move operation

### DIFF
--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -199,7 +199,7 @@ func createOrUpdateLink(binDir string, binary string, plugin string) error {
 	// Create new
 	glog.V(2).Infof("Creating symlink to %q at %q", binary, dst)
 	if err := os.Symlink(binary, dst); err != nil {
-		return errors.Wrapf(err, "failed to create a symlink form %q to %q", binDir, dst)
+		return errors.Wrapf(err, "failed to create a symlink from %q to %q", binary, dst)
 	}
 	glog.V(2).Infof("Created symlink at %q", dst)
 

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -208,7 +208,7 @@ func renameOrCopy(from, to string) error {
 }
 
 // copyTree copies files or directories, recursively.
-func copyTree(from string, to string) (err error) {
+func copyTree(from, to string) (err error) {
 	return filepath.Walk(from, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -225,7 +225,7 @@ func copyTree(from string, to string) (err error) {
 	})
 }
 
-func copyFile(source string, dst string, mode os.FileMode) (err error) {
+func copyFile(source, dst string, mode os.FileMode) (err error) {
 	sf, err := os.Open(source)
 	if err != nil {
 		return err

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -196,7 +196,7 @@ func renameOrCopy(from, to string) error {
 		glog.V(4).Infof("Move target directory %q cleaned up", to)
 	}
 
-	err = copy(from, to)
+	err = os.Rename(from, to)
 	// Fallback for invalid cross-device link (errno:18).
 	if le, ok := err.(*os.LinkError); err != nil && ok {
 		if errno, ok := le.Err.(syscall.Errno); ok && errno == 18 {

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -201,14 +201,14 @@ func renameOrCopy(from, to string) error {
 	if le, ok := err.(*os.LinkError); err != nil && ok {
 		if errno, ok := le.Err.(syscall.Errno); ok && errno == 18 {
 			glog.V(4).Infof("Cross-device link error (ERRNO=18), fallback to manual copy")
-			return copy(from, to)
+			return copyTree(from, to)
 		}
 	}
 	return err
 }
 
-// copy copies files or directories, recursively.
-func copy(from string, to string) (err error) {
+// copyTree copies files or directories, recursively.
+func copyTree(from string, to string) (err error) {
 	return filepath.Walk(from, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/pkg/installation/move_test.go
+++ b/pkg/installation/move_test.go
@@ -196,7 +196,7 @@ func Test_moveOrCopyDir_canMoveToNonExistingDir(t *testing.T) {
 
 	dst := dstDir.Path("non-existing-dir")
 
-	if err := moveOrCopyDir(srcDir.Root(), dst); err != nil {
+	if err := renameOrCopy(srcDir.Root(), dst); err != nil {
 		t.Fatalf("move failed: %+v", err)
 	}
 
@@ -225,7 +225,7 @@ func Test_moveOrCopyDir_removesExistingTarget(t *testing.T) {
 		dstDir.Write(fmt.Sprintf("file-%d", i), nil)
 	}
 
-	if err := moveOrCopyDir(srcDir.Root(), dstDir.Root()); err != nil {
+	if err := renameOrCopy(srcDir.Root(), dstDir.Root()); err != nil {
 		t.Fatalf("move failed: %+v", err)
 	}
 


### PR DESCRIPTION
It looks like we can generalize copyDir func as "copy" because filepath.Walk
works on regular files, too. Making single file move use this renameOrCopy
method.

Also fixed a typo.

This should fix #357.