### PR TITLE
Distribute LICENSE

### DIFF
--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -45,6 +45,8 @@ spec:
     files:
     - from: ./krew-darwin_amd64
       to: krew
+    - from: ./LICENSE
+      to: .
     selector:
       matchLabels:
         os: darwin
@@ -55,6 +57,8 @@ spec:
     files:
     - from: ./krew-linux_amd64
       to: krew
+    - from: ./LICENSE
+      to: .
     selector:
       matchLabels:
         os: linux
@@ -65,6 +69,8 @@ spec:
     files:
     - from: ./krew-linux_arm
       to: krew
+    - from: ./LICENSE
+      to: .
     selector:
       matchLabels:
         os: linux
@@ -75,6 +81,8 @@ spec:
     files:
     - from: ./krew-windows_amd64.exe
       to: krew.exe
+    - from: ./LICENSE
+      to: .
     selector:
       matchLabels:
         os: windows

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -28,6 +28,9 @@ fi
 krew_tar_archive="krew.tar.gz"
 krew_exe="krew.exe"
 
+# copy license
+cp -- "${SCRIPTDIR}/../LICENSE" "./${bin_dir}"
+
 # create a out/krew.exe convenience copy
 if [[ -x "./${bin_dir}/krew-windows_amd64.exe" ]]; then
   cp -- "./${bin_dir}/krew-windows_amd64.exe" "./out/krew.exe"


### PR DESCRIPTION
Ensure LICENSE is part of the release bundle for krew itself,
and is copied out to the resulting installation directory.