### PR TITLE
Preserve installation error by wrapping

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -114,6 +114,7 @@ Remarks:
 			}
 
 			var failed []string
+			var returnErr error
 			for _, plugin := range install {
 				fmt.Fprintf(os.Stderr, "Installing plugin: %s\n", plugin.Name)
 				err := installation.Install(paths, plugin, installation.InstallOpts{
@@ -125,6 +126,9 @@ Remarks:
 				}
 				if err != nil {
 					glog.Warningf("failed to install plugin %q: %v", plugin.Name, err)
+					if returnErr == nil {
+						returnErr = err
+					}
 					failed = append(failed, plugin.Name)
 					continue
 				}
@@ -135,7 +139,7 @@ Remarks:
 				internal.PrintSecurityNotice()
 			}
 			if len(failed) > 0 {
-				return errors.Errorf("failed to install some plugins: %+v", failed)
+				return errors.Wrapf(returnErr, "failed to install some plugins: %+v", failed)
 			}
 			return nil
 		},


### PR DESCRIPTION
This preserves the stack trace for errors from installation errors.

It impacts only when -v>0 specified (as that's when stack trace is printed).

Previously:

	F1113 16:05:52.448852   29304 root.go:56] failed to install some plugins: [whoami]. error=install failed: failed to unpack into staging dir: failed to unpack the plugin archive: checksum does not match, want: 121b0f750bfc3c917cccde49999f5fa09dc405f6a4896be0f8d8d3099c5d3dee, got 121b0f750bfc3c917cccde49999f5fa09dc405f6a4896be0f8d8d3099c5d3ded
	sigs.k8s.io/krew/cmd/krew/cmd.init.1.func1
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/install.go:142
	github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762
	github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852
	github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
	sigs.k8s.io/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/root.go:54
	main.main
		/Users/ahmetb/workspace/krew/cmd/krew/main.go:24
	runtime.main
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/proc.go:203
	runtime.goexit
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357

With this patch:

	F1113 16:06:20.855660   29406 root.go:56] checksum does not match, want: 121b0f750bfc3c917cccde49999f5fa09dc405f6a4896be0f8d8d3099c5d3dee, got 121b0f750bfc3c917cccde49999f5fa09dc405f6a4896be0f8d8d3099c5d3ded
	sigs.k8s.io/krew/pkg/download.sha256Verifier.Verify
		/Users/ahmetb/workspace/krew/pkg/download/verifier.go:55
	sigs.k8s.io/krew/pkg/download.download
		/Users/ahmetb/workspace/krew/pkg/download/downloader.go:50
	sigs.k8s.io/krew/pkg/download.Downloader.Get
		/Users/ahmetb/workspace/krew/pkg/download/downloader.go:230
	sigs.k8s.io/krew/pkg/installation.downloadAndExtract
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:148
	sigs.k8s.io/krew/pkg/installation.install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:106
	sigs.k8s.io/krew/pkg/installation.Install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:79
	sigs.k8s.io/krew/cmd/krew/cmd.init.1.func1
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/install.go:120
	github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762
	github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852
	github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
	sigs.k8s.io/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/root.go:54
	main.main
		/Users/ahmetb/workspace/krew/cmd/krew/main.go:24
	runtime.main
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/proc.go:203
	runtime.goexit
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357
	failed to unpack the plugin archive
	sigs.k8s.io/krew/pkg/installation.downloadAndExtract
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:149
	sigs.k8s.io/krew/pkg/installation.install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:106
	sigs.k8s.io/krew/pkg/installation.Install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:79
	sigs.k8s.io/krew/cmd/krew/cmd.init.1.func1
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/install.go:120
	github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762
	github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852
	github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
	sigs.k8s.io/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/root.go:54
	main.main
		/Users/ahmetb/workspace/krew/cmd/krew/main.go:24
	runtime.main
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/proc.go:203
	runtime.goexit
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357
	failed to unpack into staging dir
	sigs.k8s.io/krew/pkg/installation.install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:107
	sigs.k8s.io/krew/pkg/installation.Install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:79
	sigs.k8s.io/krew/cmd/krew/cmd.init.1.func1
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/install.go:120
	github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762
	github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852
	github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
	sigs.k8s.io/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/root.go:54
	main.main
		/Users/ahmetb/workspace/krew/cmd/krew/main.go:24
	runtime.main
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/proc.go:203
	runtime.goexit
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357
	install failed
	sigs.k8s.io/krew/pkg/installation.Install
		/Users/ahmetb/workspace/krew/pkg/installation/install.go:87
	sigs.k8s.io/krew/cmd/krew/cmd.init.1.func1
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/install.go:120
	github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762
	github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852
	github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
	sigs.k8s.io/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/root.go:54
	main.main
		/Users/ahmetb/workspace/krew/cmd/krew/main.go:24
	runtime.main
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/proc.go:203
	runtime.goexit
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357
	failed to install some plugins: [whoami]. error=%!v(MISSING)
	sigs.k8s.io/krew/cmd/krew/cmd.init.1.func1
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/install.go:142
	github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762
	github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852
	github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
	sigs.k8s.io/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/krew/cmd/krew/cmd/root.go:54
	main.main
		/Users/ahmetb/workspace/krew/cmd/krew/main.go:24
	runtime.main
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/proc.go:203
	runtime.goexit
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357


Fixes #384.