### PR TITLE
Refactor: move errorFetcher struct to test file

### DIFF
--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -154,6 +154,12 @@ func collectFiles(t *testing.T, scanPath string) []string {
 	return outFiles
 }
 
+var _ Fetcher = errorFetcher{}
+
+type errorFetcher struct{}
+
+func (f errorFetcher) Get(_ string) (io.ReadCloser, error) { return nil, errors.New("test fail") }
+
 func TestDownloader_Get(t *testing.T) {
 	type fields struct {
 		verifier Verifier

--- a/pkg/download/fetch.go
+++ b/pkg/download/fetch.go
@@ -53,11 +53,3 @@ func (f fileFetcher) Get(_ string) (io.ReadCloser, error) {
 
 // NewFileFetcher returns a local file reader.
 func NewFileFetcher(path string) Fetcher { return fileFetcher{f: path} }
-
-var _ Fetcher = errorFetcher{}
-
-type errorFetcher struct{}
-
-func (f errorFetcher) Get(_ string) (io.ReadCloser, error) {
-	return nil, errors.New("test fail")
-}


### PR DESCRIPTION
This fetcher was only used in its test.