### PR TITLE
Fail validation when manifest has line break in `shortDescription`

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -96,6 +96,7 @@ Examples:
 }
 
 func limitString(s string, length int) string {
+	s = strings.TrimSpace(s)
 	if len(s) > length && length > 3 {
 		s = s[:length-3] + "..."
 	}

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -96,7 +96,6 @@ Examples:
 }
 
 func limitString(s string, length int) string {
-	s = strings.TrimSpace(s)
 	if len(s) > length && length > 3 {
 		s = s[:length-3] + "..."
 	}

--- a/pkg/index/validation/validate.go
+++ b/pkg/index/validation/validate.go
@@ -79,6 +79,9 @@ func ValidatePlugin(name string, p index.Plugin) error {
 	if p.Spec.ShortDescription == "" {
 		return errors.New("should have a short description")
 	}
+	if strings.ContainsAny(p.Spec.ShortDescription, "\r\n") {
+		return errors.New("should not have line breaks in short description")
+	}
 	if len(p.Spec.Platforms) == 0 {
 		return errors.New("should have a platform specified")
 	}

--- a/pkg/index/validation/validate_test.go
+++ b/pkg/index/validation/validate_test.go
@@ -158,6 +158,24 @@ func TestValidatePlugin(t *testing.T) {
 			plugin:     testutil.NewPlugin().WithName("../foo").V(),
 			wantErr:    true,
 		},
+		{
+			name:       "short description with line break",
+			pluginName: "foo",
+			plugin:     testutil.NewPlugin().WithShortDescription("just foo\n").V(),
+			wantErr:    true,
+		},
+		{
+			name:       "short description with carriage return",
+			pluginName: "foo",
+			plugin:     testutil.NewPlugin().WithShortDescription("just foo\r").V(),
+			wantErr:    true,
+		},
+		{
+			name:       "short description with CRLF",
+			pluginName: "foo",
+			plugin:     testutil.NewPlugin().WithShortDescription("just\r\nfoo").V(),
+			wantErr:    true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #391