### PR TITLE
Bump min go to v1.13 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/krew
 
-go 1.12
+go 1.13
 
 require (
 	github.com/fatih/color v1.7.0


### PR DESCRIPTION
Since we only develop via 1.13, it's a good idea to set min go to 1.13 to give a better error message if this is the issue.