### PR TITLE
Drop GZIP env in artifact building

### DIFF
--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -46,7 +46,7 @@ done < <(find "${bin_dir}" -print0)
 echo >&2 "Creating ${krew_tar_archive} archive."
 (
   cd "${bin_dir}"
-  tar -I "gzip --best" -cvf "${SCRIPTDIR}/../out/${krew_tar_archive}" ./*
+  tar --use-compress-program "gzip --no-name" -cvf "${SCRIPTDIR}/../out/${krew_tar_archive}" ./*
 )
 
 checksum_cmd="shasum -a 256"

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -46,7 +46,7 @@ done < <(find "${bin_dir}" -print0)
 echo >&2 "Creating ${krew_tar_archive} archive."
 (
   cd "${bin_dir}"
-  tar -I "gzip -${n}" -cvf "${SCRIPTDIR}/../out/${krew_tar_archive}" ./*
+  tar -I "gzip --best" -cvf "${SCRIPTDIR}/../out/${krew_tar_archive}" ./*
 )
 
 checksum_cmd="shasum -a 256"

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -46,7 +46,7 @@ done < <(find "${bin_dir}" -print0)
 echo >&2 "Creating ${krew_tar_archive} archive."
 (
   cd "${bin_dir}"
-  GZIP=-n tar czvf "${SCRIPTDIR}/../out/${krew_tar_archive}" ./*
+  tar -I "gzip -${n}" -cvf "${SCRIPTDIR}/../out/${krew_tar_archive}" ./*
 )
 
 checksum_cmd="shasum -a 256"


### PR DESCRIPTION
> warning: GZIP environment variable is deprecated; use an alias or script

handle warning with `-I / --use-compress-program=PROG`