### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,5 +2,4 @@ aliases:
   krew-maintainers:
     - ahmetb
     - corneliusweig
-    - juanvallejo
     - soltysh

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,4 +11,4 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 ahmetb
-juanvallejo
+corneliusweig


### PR DESCRIPTION
Per kubernetes/org#1396 Juan no longer has admin or maintainer access to krew-index due to inactivity. As long as he is in the OWNERS file, Prow will request review by him which won't happen. This should fix it.