### PR TITLE
pkg/index: ignore non-.yaml files during scanning

### DIFF
--- a/pkg/index/indexscanner/scanner.go
+++ b/pkg/index/indexscanner/scanner.go
@@ -36,9 +36,9 @@ func findPluginManifestFiles(indexDir string) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open index dir")
 	}
-	for _, fi := range files {
-		if fi.Mode().IsRegular() && filepath.Ext(fi.Name()) == constants.ManifestExtension {
-			out = append(out, fi.Name())
+	for _, file := range files {
+		if file.Mode().IsRegular() && filepath.Ext(file.Name()) == constants.ManifestExtension {
+			out = append(out, file.Name())
 		}
 	}
 	return out, nil
@@ -58,8 +58,8 @@ func LoadPluginListFromFS(indexDir string) ([]index.Plugin, error) {
 	klog.V(4).Infof("found %d plugins in dir %s", len(files), indexDir)
 
 	list := make([]index.Plugin, 0, len(files))
-	for _, fn := range files {
-		pluginName := strings.TrimSuffix(fn, filepath.Ext(fn))
+	for _, file := range files {
+		pluginName := strings.TrimSuffix(file, filepath.Ext(file))
 		p, err := LoadPluginFileFromFS(indexDir, pluginName)
 		if err != nil {
 			// Index loading shouldn't fail because of one plugin.


### PR DESCRIPTION
Turns out if there was a file in index/ directory with a non-.yaml extension,
we still targeted that as a plugin, so we tried to parse its manifest. (But
read/parsing of individual manifests do not cause fatal errors, just printed
to stderr like a warning.)

This creates a helper method that properly scans for .yaml files in an
immediate directory.

Fixes #412 
/assign @corneliusweig