### PR TITLE
Remove license header from krew.yaml

### DIFF
--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -1,17 +1,3 @@
-# Copyright 2019 The Kubernetes Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:


### PR DESCRIPTION
Consistency with other plugin manifests at krew-index repository.