### PR TITLE
Drop sudo from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: go
 go:
 - 1.13.x


### PR DESCRIPTION
Dro sudo config for travis.

Travis deprecated docker based environment and that's not used anymore.