### PR TITLE
Support reading manifest url from files

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -77,6 +77,10 @@ Remarks:
 				}
 			}
 
+			if *manifest != "" && *manifestURL != "" {
+				return errors.New("cannot specify --manifest and --manifest-url at the same time")
+			}
+
 			if len(pluginNames) != 0 && (*manifest != "" || *manifestURL != "") {
 				return errors.New("must specify either specify either plugin names (via positional arguments or STDIN), or --manifest/--manifest-url; not both")
 			}

--- a/cmd/krew/cmd/install_test.go
+++ b/cmd/krew/cmd/install_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func Test_readPluginFromURL(t *testing.T) {
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join("../../../integration_test/testdata"))))
+	defer server.Close()
+
+	tests := []struct {
+		name     string
+		url      string
+		wantName string
+		wantErr  bool
+	}{
+		{
+			name:     "successful request",
+			url:      server.URL + "/konfig.yaml",
+			wantName: "konfig",
+		},
+		{
+			name:    "invalid server",
+			url:     "http://example.invalid:80/foo.yaml",
+			wantErr: true,
+		},
+		{
+			name:    "bad response",
+			url:     server.URL + "/404.yaml",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readPluginFromURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readPluginFromURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.Name != tt.wantName {
+				t.Fatalf("readPluginFromURL() returned name=%v; want=%v", got.Name, tt.wantName)
+			}
+		})
+	}
+}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -62,7 +62,7 @@ kubectl krew upgrade foo bar"`,
 
 			var nErrors int
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(), name)
 				if err != nil {
 					if os.IsNotExist(err) {
 						return errors.Errorf("plugin %q does not exist in the plugin index", name)

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -64,7 +64,7 @@ func main() {
 
 func validateManifestFile(path string) error {
 	klog.V(4).Infof("reading file %s", path)
-	p, err := indexscanner.ReadPluginFile(path)
+	p, err := indexscanner.ReadPluginFromFile(path)
 	if err != nil {
 		return errors.Wrap(err, "failed to read plugin file")
 	}

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -156,7 +156,7 @@ func TestKrewInstall_ManifestArgsAreMutuallyExclusive(t *testing.T) {
 	srv, close := localTestServer()
 	defer close()
 
-	if err := test.Krew("install", validPlugin,
+	if err := test.Krew("install",
 		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),
 		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
 		Run(); err == nil {

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -112,8 +112,8 @@ func TestKrewInstall_ManifestURL(t *testing.T) {
 
 	test, cleanup := NewTest(t)
 	defer cleanup()
-	srv, close := localTestServer()
-	defer close()
+	srv, shutdown := localTestServer()
+	defer shutdown()
 
 	test.Krew("install",
 		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
@@ -153,8 +153,8 @@ func TestKrewInstall_ManifestArgsAreMutuallyExclusive(t *testing.T) {
 
 	test, cleanup := NewTest(t)
 	defer cleanup()
-	srv, close := localTestServer()
-	defer close()
+	srv, shutdown := localTestServer()
+	defer shutdown()
 
 	if err := test.Krew("install",
 		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -15,6 +15,8 @@
 package integrationtest
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -105,6 +107,20 @@ func TestKrewInstall_Manifest(t *testing.T) {
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
 }
 
+func TestKrewInstall_ManifestURL(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+	srv, close := localTestServer()
+	defer close()
+
+	test.Krew("install",
+		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
+		RunOrFail()
+	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+}
+
 func TestKrewInstall_ManifestAndArchive(t *testing.T) {
 	skipShort(t)
 
@@ -132,7 +148,23 @@ func TestKrewInstall_OnlyArchive(t *testing.T) {
 	}
 }
 
-func TestKrewInstall_PositionalArgumentsAndManifest(t *testing.T) {
+func TestKrewInstall_ManifestArgsAreMutuallyExclusive(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+	srv, close := localTestServer()
+	defer close()
+
+	if err := test.Krew("install", validPlugin,
+		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),
+		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
+		Run(); err == nil {
+		t.Fatal("expected mutually exclusive arguments to cause failure")
+	}
+}
+
+func TestKrewInstall_NoManifestArgsWhenPositionalArgsSpecified(t *testing.T) {
 	skipShort(t)
 
 	test, cleanup := NewTest(t)
@@ -143,6 +175,17 @@ func TestKrewInstall_PositionalArgumentsAndManifest(t *testing.T) {
 		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
 		Run()
 	if err == nil {
-		t.Fatal("expected failure")
+		t.Fatal("expected failure when positional args and --manifest specified")
 	}
+
+	err = test.Krew("install", validPlugin,
+		"--manifest-url", filepath.Join("testdata", fooPlugin+constants.ManifestExtension)).Run()
+	if err == nil {
+		t.Fatal("expected failure when positional args and --manifest-url specified")
+	}
+}
+
+func localTestServer() (string, func()) {
+	s := httptest.NewServer(http.FileServer(http.Dir("testdata")))
+	return s.URL, s.Close
 }

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -28,7 +28,7 @@ import (
 // LoadManifestFromReceiptOrIndex tries to load a plugin manifest from the
 // receipts directory or from the index directory if the former fails.
 func LoadManifestFromReceiptOrIndex(p environment.Paths, name string) (index.Plugin, error) {
-	receipt, err := indexscanner.LoadPluginFileFromFS(p.InstallReceiptsPath(), name)
+	receipt, err := indexscanner.LoadPluginByName(p.InstallReceiptsPath(), name)
 
 	if err == nil {
 		klog.V(3).Infof("Found plugin manifest for %q in the receipts dir", name)
@@ -40,5 +40,5 @@ func LoadManifestFromReceiptOrIndex(p environment.Paths, name string) (index.Plu
 	}
 
 	klog.V(3).Infof("Plugin manifest for %q not found in the receipts dir", name)
-	return indexscanner.LoadPluginFileFromFS(p.IndexPluginsPath(), name)
+	return indexscanner.LoadPluginByName(p.IndexPluginsPath(), name)
 }

--- a/internal/installation/receipt/receipt.go
+++ b/internal/installation/receipt/receipt.go
@@ -39,5 +39,5 @@ func Store(plugin index.Plugin, dest string) error {
 // Load reads the plugin receipt at the specified destination.
 // If not found, it returns os.IsNotExist error.
 func Load(path string) (index.Plugin, error) {
-	return indexscanner.ReadPluginFile(path)
+	return indexscanner.ReadPluginFromFile(path)
 }

--- a/internal/installation/receipt/receipt_test.go
+++ b/internal/installation/receipt/receipt_test.go
@@ -35,7 +35,7 @@ func TestStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := indexscanner.LoadPluginFileFromFS(tmpDir.Root(), "some-plugin")
+	actual, err := indexscanner.LoadPluginByName(tmpDir.Root(), "some-plugin")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Addressing some technical debt:

- Introduce indexscanner.ReadPlugin(io.ReadCloser)
- Make ReadPluginFromFile use that to simplify
- Move validation.ValidatePlugin from several places to ReadPlugin() method
- Add missing test for "preserves ENOENT" behavior for ReadPluginFromFile
- Fix verify-gofmt.sh reference (now gone) in run-tests.sh

Adding new stuff:

- introduce --manifest-url that is mut.ex. with --manifest and positional args
- add unit tests for url fetching
- add integration tests for --manifest-url argument behavior

Addresses #193, potentially supersedes #350.