### PR TITLE
cmd: Friendly error messages when plugin not found

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"bufio"
-	errs "errors"
 	"fmt"
 	"os"
 
@@ -100,7 +99,7 @@ Remarks:
 				}
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
-					if errs.Is(err, os.ErrNotExist) {
+					if os.IsNotExist(err) {
 						return fmt.Errorf("plugin \"%s\" does not exist in the plugin index", name)
 					}
 					return errors.Wrapf(err, "failed to load plugin %q from the index", name)

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"bufio"
+	errs "errors"
 	"fmt"
 	"os"
 
@@ -89,6 +90,9 @@ Remarks:
 			for _, name := range pluginNames {
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
+					if errs.Is(err, os.ErrNotExist) {
+						return errors.New(fmt.Sprintf("plugin \"%s\" does not exist in the plugin index", name))
+					}
 					return errors.Wrapf(err, "failed to load plugin %q from the index", name)
 				}
 				install = append(install, plugin)

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -90,7 +90,7 @@ Remarks:
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
 					if os.IsNotExist(err) {
-						return errors.New(fmt.Sprintf("plugin %q does not exist in the plugin index", name))
+						return errors.Errorf("plugin %q does not exist in the plugin index", name)
 					}
 					return errors.Wrapf(err, "failed to load plugin %q from the index", name)
 				}

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -85,22 +85,12 @@ Remarks:
 				return errors.New("--archive can be specified only with --manifest")
 			}
 
-			installed, err := installation.ListInstalledPlugins(paths.InstallReceiptsPath())
-			if err != nil {
-				return errors.Wrap(err, "failed to find all installed versions")
-			}
-			skipped := false
 			var install []index.Plugin
 			for _, name := range pluginNames {
-				if _, ok := installed[name]; ok {
-					fmt.Fprintf(os.Stderr, "plugin \"%s\" is already installed\n", name)
-					skipped = true
-					continue
-				}
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
 					if os.IsNotExist(err) {
-						return fmt.Errorf("plugin \"%s\" does not exist in the plugin index", name)
+						return errors.New(fmt.Sprintf("plugin %q does not exist in the plugin index", name))
 					}
 					return errors.Wrapf(err, "failed to load plugin %q from the index", name)
 				}
@@ -119,9 +109,6 @@ Remarks:
 			}
 
 			if len(install) == 0 {
-				if skipped {
-					return nil
-				}
 				return cmd.Help()
 			}
 

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -66,7 +66,7 @@ kubectl krew upgrade foo bar"`,
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
 					if errs.Is(err, os.ErrNotExist) {
-						return errors.New(fmt.Sprintf("plugin \"%s\" does not exist in the plugin index", name))
+						return fmt.Errorf("plugin \"%s\" does not exist in the plugin index", name)
 					}
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	errs "errors"
 	"fmt"
 	"os"
 
@@ -65,7 +64,7 @@ kubectl krew upgrade foo bar"`,
 			for _, name := range pluginNames {
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
-					if errs.Is(err, os.ErrNotExist) {
+					if os.IsNotExist(err) {
 						return fmt.Errorf("plugin \"%s\" does not exist in the plugin index", name)
 					}
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -65,7 +65,7 @@ kubectl krew upgrade foo bar"`,
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
 					if os.IsNotExist(err) {
-						return errors.New(fmt.Sprintf("plugin %q does not exist in the plugin index", name))
+						return errors.Errorf("plugin %q does not exist in the plugin index", name)
 					}
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -65,7 +65,7 @@ kubectl krew upgrade foo bar"`,
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
 					if os.IsNotExist(err) {
-						return fmt.Errorf("plugin \"%s\" does not exist in the plugin index", name)
+						return errors.New(fmt.Sprintf("plugin %q does not exist in the plugin index", name))
 					}
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	errs "errors"
 	"fmt"
 	"os"
 
@@ -64,6 +65,9 @@ kubectl krew upgrade foo bar"`,
 			for _, name := range pluginNames {
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPluginsPath(), name)
 				if err != nil {
+					if errs.Is(err, os.ErrNotExist) {
+						return errors.New(fmt.Sprintf("plugin \"%s\" does not exist in the plugin index", name))
+					}
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}
 

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -40,9 +40,6 @@ trap print_status EXIT
 print_with_color "$color_blue" 'Checking boilerplate'
 "$SCRIPTDIR"/verify-boilerplate.sh
 
-print_with_color "$color_blue" 'Running gofmt'
-"$SCRIPTDIR"/verify-gofmt.sh
-
 print_with_color "$color_blue" 'Running tests'
 go test -short -race sigs.k8s.io/krew/...
 


### PR DESCRIPTION
Fixes #431 

I decided to just use `os.IsNotExist` on the error rather than `errors.Is` since there's a package name conflict with the existing `github.com/pkg/errors` package. I was thinking about using the new %w verb in `fmt.Errorf` but noticed that you lose stack trace info when setting the log level. There's an existing issue, https://github.com/kubernetes-sigs/krew/issues/414, that is open to consider using 1.13 logging so I figured I'd use this for now and we could change it when the other issue gets figured out.