### PR TITLE
Show "Upgrading plugin %s" message

### DIFF
--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -67,7 +67,7 @@ kubectl krew upgrade foo bar"`,
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}
 
-				fmt.Fprintf(os.Stderr, 	"Upgrading plugin: %s\n", plugin.Name)
+				fmt.Fprintf(os.Stderr, "Upgrading plugin: %s\n", plugin.Name)
 				err = installation.Upgrade(paths, plugin)
 				if ignoreUpgraded && err == installation.ErrIsAlreadyUpgraded {
 					fmt.Fprintf(os.Stderr, "Skipping plugin %s, it is already on the newest version\n", plugin.Name)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -67,7 +67,7 @@ kubectl krew upgrade foo bar"`,
 					return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)
 				}
 
-				klog.V(2).Infof("Upgrading plugin: %s\n", plugin.Name)
+				fmt.Fprintf(os.Stderr, 	"Upgrading plugin: %s\n", plugin.Name)
 				err = installation.Upgrade(paths, plugin)
 				if ignoreUpgraded && err == installation.ErrIsAlreadyUpgraded {
 					fmt.Fprintf(os.Stderr, "Skipping plugin %s, it is already on the newest version\n", plugin.Name)


### PR DESCRIPTION
Promoting this from log to user-visible message, because some plugins actually
are ~20-30 MiB and takes a significant time to download. During this time
we show no indication of progress while the download is happening.

/assign @corneliusweig