### PR TITLE
Disable all first then enable needed linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,21 +36,22 @@ run:
   tests: true
 
 linters:
+  disable-all: true
   enable:
-    - gofmt
+    - deadcode
+    - errcheck
     - gocritic
+    - gofmt
     - goimports
     - golint
     - gosimple
     - interfacer
     - maligned
     - misspell
-    - unconvert
-    - unparam
-    - stylecheck
+    - prealloc
     - staticcheck
     - structcheck
-    - prealloc
-    - deadcode
+    - stylecheck
+    - unconvert
+    - unparam
     - varcheck
-    - errcheck


### PR DESCRIPTION
First disable all linters then enable what we need. Otherwise, all linters are running then results are filtered. See with `-v` flag.

Also, sort enabled linters in config.