### PR TITLE
Bump golangci-lint to v1.22.2

### DIFF
--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -23,7 +23,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
   echo >&2 'Installing golangci-lint'
   curl --silent --fail --location \
-    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.21.0
+    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.22.2
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
Regular bump of lint tool to the latest. 