### PR TITLE
allow linux/arm64 plugins

### DIFF
--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -196,6 +196,7 @@ func allPlatforms() []installation.OSArchPair {
 		{OS: "linux", Arch: "386"},
 		{OS: "linux", Arch: "amd64"},
 		{OS: "linux", Arch: "arm"},
+		{OS: "linux", Arch: "arm64"},
 		{OS: "darwin", Arch: "386"},
 		{OS: "darwin", Arch: "amd64"},
 	}


### PR DESCRIPTION
This came up in https://github.com/kubernetes-sigs/krew-index/pull/407.
We don't currently release krew for linux/arm64, but apparently linux/arm
distribution we have works there.

This would allow plugins to be distributed for linux/arm64, in addition to
existing linux/arm.

/assign @corneliusweig