### PR TITLE
Ensure go mod is tidied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 - go mod download
 - hack/install-gox.sh
 script:
+- go mod tidy && git diff --no-patch --exit-code
 - hack/verify-code-patterns.sh
 - hack/verify-boilerplate.sh
 - hack/run-lint.sh


### PR DESCRIPTION
Sometimes when a dependency is added, it could be forgotten to be tidied.
This ensures it's always tidied. 