### PR TITLE
run-integration-tests.sh: pass args down

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -22,18 +22,24 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BINDIR="${SCRIPTDIR}/../out/bin"
 goos="$(go env GOOS)"
 goarch="$(go env GOARCH)"
-KREW_BINARY_DEFAULT="${BINDIR}/krew-${goos}_${goarch}"
+krew_binary_default="${BINDIR}/krew-${goos}_${goarch}"
 
 if [[ "$#" -gt 0 && ("$1" == '-h' || "$1" == '--help') ]]; then
   cat <<EOF
+Runs the integration tests against built krew binary.
+Set KREW_BINARY to use a krew binary at a different location.
+Positional arguments are passed to the underlying 'go test'.
+
 Usage:
-  $0 krew  # uses the given krew binary for running integration tests
-  $0       # assumes a pre-built krew binary at $KREW_BINARY_DEFAULT
+  $0
+  $0 -test.v -test.run TestFoo
+  env KREW_BINARY=[FILE] $0
 EOF
   exit 0
 fi
 
-KREW_BINARY="${1:-$KREW_BINARY_DEFAULT}" # needed for `kubectl krew` in tests
+KREW_BINARY="${KREW_BINARY:-$krew_binary_default}" # needed for `kubectl krew` in tests
+
 if [[ ! -e "${KREW_BINARY}" ]]; then
   echo >&2 "Could not find $KREW_BINARY. You need to build krew for ${goos}/${goarch} before running the integration tests."
   exit 1
@@ -46,4 +52,4 @@ fi
 KREW_BINARY="${krew_binary_realpath}"
 export KREW_BINARY
 
-go test sigs.k8s.io/krew/integration_test
+go test sigs.k8s.io/krew/integration_test "$@"


### PR DESCRIPTION
- make this script accept KREW_BINARY for a custom binary path instead of $1
- pass args ($@) to "go test" so I can do stuff like "-v -run TestXyz"