### PR TITLE
Add support for custom indices

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -16,11 +16,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/krew/internal/index/indexoperations"
 )
+
+var indexConfig *indexoperations.IndexConfig
 
 // indexCmd represents the index command
 var indexCmd = &cobra.Command{
@@ -37,12 +40,7 @@ var indexAddCmd = &cobra.Command{
 	Short: "Add a custom index to download plugins from",
 	Long:  "Add a custom index to download plugins from",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("index add: %+v\n", args)
-		indexConfig, err := indexoperations.GetIndexConfig()
-		if err != nil {
-			return err
-		}
-		return indexConfig.WriteIndexConfig(args[0], args[1])
+		return indexConfig.AddIndex(args[0], args[1])
 	},
 }
 
@@ -51,10 +49,6 @@ var indexRemoveCmd = &cobra.Command{
 	Short: "Remove a custom index that you've added",
 	Long:  "Remove a custom index that you've added",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		indexConfig, err := indexoperations.GetIndexConfig()
-		if err != nil {
-			return err
-		}
 		return indexConfig.RemoveIndex(args[0])
 	},
 }
@@ -65,16 +59,18 @@ var indexListCmd = &cobra.Command{
 	Long:  "List configured indices",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		indexConfig, err := indexoperations.GetIndexConfig()
-		if err != nil {
-			return err
-		}
 		fmt.Printf("%+v\n", indexConfig.Indices)
 		return nil
 	},
 }
 
 func init() {
+	ic, err := indexoperations.GetIndexConfig()
+	if err != nil {
+		fmt.Println("AHHHHHHHHH!")
+		os.Exit(1)
+	}
+	indexConfig = ic
 	indexCmd.AddCommand(indexAddCmd)
 	indexCmd.AddCommand(indexRemoveCmd)
 	indexCmd.AddCommand(indexListCmd)

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/krew/internal/index/indexoperations"
+)
+
+// indexCmd represents the index command
+var indexCmd = &cobra.Command{
+	Use:    "index",
+	Short:  "Perform krew index commands",
+	Long:   "Perform krew index commands such as adding and removing indices.",
+	Args:   cobra.NoArgs,
+	Hidden: true,
+}
+
+// indexAddCmd represents the index add command
+var indexAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a custom index to download plugins from",
+	Long:  "Add a custom index to download plugins from",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Printf("index add: %+v\n", args)
+		indexConfig, err := indexoperations.GetIndexConfig()
+		if err != nil {
+			return err
+		}
+		return indexConfig.WriteIndexConfig(args[0], args[1])
+	},
+}
+
+var indexListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured indices",
+	Long:  "List configured indices",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		indexConfig, err := indexoperations.GetIndexConfig()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%+v\n", indexConfig.Indices)
+		return nil
+	},
+}
+
+func init() {
+	indexCmd.AddCommand(indexAddCmd)
+	indexCmd.AddCommand(indexListCmd)
+	rootCmd.AddCommand(indexCmd)
+}

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -27,7 +27,9 @@ var indexCmd = &cobra.Command{
 	Short: "Perform krew index commands",
 	Long:  "Perform krew index commands such as adding and removing indices.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("%+v\n", indexConfig.Indices)
+		if len(indexConfig.Indices) != 0 {
+			fmt.Printf("%+v\n", indexConfig.Indices)
+		}
 		return nil
 	},
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -19,11 +19,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-
-	"sigs.k8s.io/krew/internal/index/indexoperations"
 )
-
-var indexConfig *indexoperations.IndexConfig
 
 // indexCmd represents the index command
 var indexCmd = &cobra.Command{
@@ -60,12 +56,6 @@ var indexRemoveCmd = &cobra.Command{
 }
 
 func init() {
-	ic, err := indexoperations.GetIndexConfig()
-	if err != nil {
-		fmt.Println("AHHHHHHHHH!")
-		os.Exit(1)
-	}
-	indexConfig = ic
 	indexCmd.AddCommand(indexAddCmd)
 	indexCmd.AddCommand(indexRemoveCmd)
 	rootCmd.AddCommand(indexCmd)

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -49,6 +49,10 @@ var indexRemoveCmd = &cobra.Command{
 	Short: "Remove a custom index that you've added",
 	Long:  "Remove a custom index that you've added",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			fmt.Printf("Must provide an index name that you want to remove")
+			os.Exit(1)
+		}
 		return indexConfig.RemoveIndex(args[0])
 	},
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -46,6 +46,19 @@ var indexAddCmd = &cobra.Command{
 	},
 }
 
+var indexRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a custom index that you've added",
+	Long:  "Remove a custom index that you've added",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		indexConfig, err := indexoperations.GetIndexConfig()
+		if err != nil {
+			return err
+		}
+		return indexConfig.RemoveIndex(args[0])
+	},
+}
+
 var indexListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List configured indices",
@@ -63,6 +76,7 @@ var indexListCmd = &cobra.Command{
 
 func init() {
 	indexCmd.AddCommand(indexAddCmd)
+	indexCmd.AddCommand(indexRemoveCmd)
 	indexCmd.AddCommand(indexListCmd)
 	rootCmd.AddCommand(indexCmd)
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -27,11 +27,13 @@ var indexConfig *indexoperations.IndexConfig
 
 // indexCmd represents the index command
 var indexCmd = &cobra.Command{
-	Use:    "index",
-	Short:  "Perform krew index commands",
-	Long:   "Perform krew index commands such as adding and removing indices.",
-	Args:   cobra.NoArgs,
-	Hidden: true,
+	Use:   "index",
+	Short: "Perform krew index commands",
+	Long:  "Perform krew index commands such as adding and removing indices.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Printf("%+v\n", indexConfig.Indices)
+		return nil
+	},
 }
 
 // indexAddCmd represents the index add command
@@ -57,17 +59,6 @@ var indexRemoveCmd = &cobra.Command{
 	},
 }
 
-var indexListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List configured indices",
-	Long:  "List configured indices",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("%+v\n", indexConfig.Indices)
-		return nil
-	},
-}
-
 func init() {
 	ic, err := indexoperations.GetIndexConfig()
 	if err != nil {
@@ -77,6 +68,5 @@ func init() {
 	indexConfig = ic
 	indexCmd.AddCommand(indexAddCmd)
 	indexCmd.AddCommand(indexRemoveCmd)
-	indexCmd.AddCommand(indexListCmd)
 	rootCmd.AddCommand(indexCmd)
 }

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -91,7 +92,16 @@ Remarks:
 
 			var install []index.Plugin
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(), name)
+				var pluginPath, pluginName string
+				if strings.Contains(name, "/") {
+					p := strings.Split(name, "/")
+					pluginPath = paths.CustomIndexPluginsPath(p[0])
+					pluginName = p[1]
+				} else {
+					pluginPath = paths.IndexPluginsPath()
+					pluginName = name
+				}
+				plugin, err := indexscanner.LoadPluginByName(pluginPath, pluginName)
 				if err != nil {
 					if os.IsNotExist(err) {
 						return errors.Errorf("plugin %q does not exist in the plugin index", name)

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/internal/installation"
 )
 
@@ -44,10 +43,6 @@ Remarks:
 			plugins, err := installation.ListInstalledPlugins(paths.InstallReceiptsPath())
 			if err != nil {
 				return errors.Wrap(err, "failed to find all installed versions")
-			}
-			indexConfig, err := indexoperations.GetIndexConfig()
-			if err != nil {
-				return errors.Wrap(err, "error getting index config")
 			}
 			customIndexPlugins := make(map[string]string)
 			for index := range indexConfig.Indices {

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -108,7 +108,7 @@ func preRun(cmd *cobra.Command, _ []string) error {
 }
 
 func cleanupStaleKrewInstallations() error {
-	r, err := receipt.Load(paths.PluginInstallReceiptPath(constants.KrewPluginName))
+	r, err := receipt.Load(paths.PluginInstallReceiptPath(constants.KrewPluginName, ""))
 	if os.IsNotExist(err) {
 		klog.V(1).Infof("could not find krew's own plugin receipt, skipping cleanup of stale krew installations")
 		return nil
@@ -118,7 +118,7 @@ func cleanupStaleKrewInstallations() error {
 	v := r.Spec.Version
 
 	klog.V(1).Infof("Clean up krew stale installations, current=%s", v)
-	return installation.CleanupStaleKrewInstallations(paths.PluginInstallPath(constants.KrewPluginName), v)
+	return installation.CleanupStaleKrewInstallations(paths.PluginInstallPath(constants.KrewPluginName, ""), v)
 }
 
 func checkIndex(_ *cobra.Command, _ []string) error {

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/gitutil"
+	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/installation/receipt"
 	"sigs.k8s.io/krew/internal/receiptsmigration"
@@ -34,7 +35,8 @@ import (
 )
 
 var (
-	paths environment.Paths // krew paths used by the process
+	paths       environment.Paths // krew paths used by the process
+	indexConfig indexoperations.IndexConfig
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -83,6 +85,11 @@ func init() {
 		paths.InstallReceiptsPath()); err != nil {
 		klog.Fatal(err)
 	}
+	ic, err := indexoperations.GetIndexConfig()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	indexConfig = *ic
 }
 
 func preRun(cmd *cobra.Command, _ []string) error {

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/krew/internal/gitutil"
+	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/pkg/constants"
@@ -108,6 +109,15 @@ func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
 	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath())
 	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath()); err != nil {
 		return errors.Wrap(err, "failed to update the local index")
+	}
+	indexConfig, err := indexoperations.GetIndexConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed getting custom index config")
+	}
+	for index, uri := range indexConfig.Indices {
+		if err := gitutil.EnsureUpdated(uri, paths.CustomIndexPath(index)); err != nil {
+			return errors.Wrapf(err, "failed to update the local custom index %q", index)
+		}
 	}
 	fmt.Fprintln(os.Stderr, "Updated the local copy of plugin index.")
 

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/krew/internal/gitutil"
-	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/pkg/constants"
@@ -109,10 +108,6 @@ func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
 	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath())
 	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath()); err != nil {
 		return errors.Wrap(err, "failed to update the local index")
-	}
-	indexConfig, err := indexoperations.GetIndexConfig()
-	if err != nil {
-		return errors.Wrap(err, "failed getting custom index config")
 	}
 	for index, uri := range indexConfig.Indices {
 		if err := gitutil.EnsureUpdated(uri, paths.CustomIndexPath(index)); err != nil {

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/krew/cmd/krew/cmd/internal"
-	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/pkg/index"
@@ -55,10 +54,6 @@ kubectl krew upgrade foo bar"`,
 				}
 				for name := range installed {
 					pluginNames = append(pluginNames, map[string]string{"name": name, "index": ""})
-				}
-				indexConfig, err := indexoperations.GetIndexConfig()
-				if err != nil {
-					return errors.Wrap(err, "failed to load index config")
 				}
 				for index := range indexConfig.Indices {
 					installed, err = installation.ListInstalledPlugins(paths.PluginInstallReceipts(index))

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/apimachinery v0.0.0-20190717022731-0bb8574e0887
 	k8s.io/client-go v7.0.0+incompatible
 	k8s.io/klog v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/apimachinery v0.0.0-20190717022731-0bb8574e0887
 	k8s.io/client-go v7.0.0+incompatible
 	k8s.io/klog v1.0.0

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestKrewIndex(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	initialIndices := test.Krew("index").RunOrFailOutput()
+	initialOut := []byte{}
+	if diff := cmp.Diff(initialIndices, initialOut); diff != "" {
+		t.Fatalf("expected empty output from 'index':\n%s", diff)
+	}
+
+	test.Krew("index", "add", "test", "https://github.com/kubernetes-sigs/krew-index.git").RunOrFail()
+	expected := []byte("map[test:https://github.com/kubernetes-sigs/krew-index.git]\n")
+	eventual := test.Krew("index").RunOrFailOutput()
+	if diff := cmp.Diff(eventual, expected); diff != "" {
+		t.Fatalf("'index' output doesn't match:\n%s", diff)
+	}
+
+	test.Krew("index", "add", "test2", "https://github.com/kubernetes-sigs/krew-index.git").RunOrFail()
+	expected = []byte("map[test:https://github.com/kubernetes-sigs/krew-index.git test2:https://github.com/kubernetes-sigs/krew-index.git]\n")
+	eventual = test.Krew("index").RunOrFailOutput()
+	if diff := cmp.Diff(eventual, expected); diff != "" {
+		t.Fatalf("'index' output doesn't match:\n%s", diff)
+	}
+
+	test.Krew("index", "remove", "test").RunOrFail()
+	expected = []byte("map[test2:https://github.com/kubernetes-sigs/krew-index.git]\n")
+	eventual = test.Krew("index").RunOrFailOutput()
+	if diff := cmp.Diff(eventual, expected); diff != "" {
+		t.Fatalf("'index' output doesn't match:\n%s", diff)
+	}
+
+	test.Krew("index", "remove", "test2").RunOrFail()
+	expected = []byte{}
+	eventual = test.Krew("index").RunOrFailOutput()
+	if diff := cmp.Diff(eventual, expected); diff != "" {
+		t.Fatalf("'index' output doesn't match:\n%s", diff)
+	}
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -100,6 +100,10 @@ func (p Paths) IndexConfigPath() string {
 	return p.base
 }
 
+func (p Paths) PluginInstallReceipts(index string) string {
+	return filepath.Join(p.InstallReceiptsPath(), index)
+}
+
 // PluginInstallReceiptPath returns the path to the install receipt for plugin.
 //
 // e.g. {InstallReceiptsPath}/{plugin}.yaml

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -92,7 +92,11 @@ func (p Paths) InstallPath() string { return filepath.Join(p.base, "store") }
 //
 // e.g. {InstallPath}/{version}/{..files..}
 func (p Paths) PluginInstallPath(plugin, index string) string {
-	return filepath.Join(p.InstallPath(), index, plugin)
+	indexSubdir := ""
+	if index != "" {
+		indexSubdir = "krew-indices"
+	}
+	return filepath.Join(p.InstallPath(), indexSubdir, index, plugin)
 }
 
 // IndexConfigPath returns the path to the directory where the configuration for indices is.
@@ -116,7 +120,11 @@ func (p Paths) PluginInstallReceiptPath(plugin, index string) string {
 //
 // e.g. {PluginInstallPath}/{plugin}/{version}
 func (p Paths) PluginVersionInstallPath(index, plugin, version string) string {
-	return filepath.Join(p.InstallPath(), index, plugin, version)
+	indexSubdir := ""
+	if index != "" {
+		indexSubdir = "krew-indices"
+	}
+	return filepath.Join(p.InstallPath(), indexSubdir, index, plugin, version)
 }
 
 // Realpath evaluates symbolic links. If the path is not a symbolic link, it

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -59,6 +59,9 @@ func (p Paths) BasePath() string { return p.base }
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath() string { return filepath.Join(p.base, "index") }
 
+// CustomIndicesPath returns the directory to the custom indices that have been added
+func (p Paths) CustomIndicesPath(dir string) string { return filepath.Join(p.base, "custom", dir) }
+
 // IndexPluginsPath returns the plugins directory of the index repository.
 //
 // e.g. {BasePath}/index/plugins/

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -87,6 +87,11 @@ func (p Paths) PluginInstallPath(plugin string) string {
 	return filepath.Join(p.InstallPath(), plugin)
 }
 
+// IndexConfigPath returns the path to the directory where the configuration for indices is.
+func (p Paths) IndexConfigPath() string {
+	return p.base
+}
+
 // PluginInstallReceiptPath returns the path to the install receipt for plugin.
 //
 // e.g. {InstallReceiptsPath}/{plugin}.yaml

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -91,8 +91,8 @@ func (p Paths) InstallPath() string { return filepath.Join(p.base, "store") }
 // PluginInstallPath returns the path to install the plugin.
 //
 // e.g. {InstallPath}/{version}/{..files..}
-func (p Paths) PluginInstallPath(plugin string) string {
-	return filepath.Join(p.InstallPath(), plugin)
+func (p Paths) PluginInstallPath(plugin, index string) string {
+	return filepath.Join(p.InstallPath(), index, plugin)
 }
 
 // IndexConfigPath returns the path to the directory where the configuration for indices is.
@@ -103,16 +103,16 @@ func (p Paths) IndexConfigPath() string {
 // PluginInstallReceiptPath returns the path to the install receipt for plugin.
 //
 // e.g. {InstallReceiptsPath}/{plugin}.yaml
-func (p Paths) PluginInstallReceiptPath(plugin string) string {
-	return filepath.Join(p.InstallReceiptsPath(), plugin+constants.ManifestExtension)
+func (p Paths) PluginInstallReceiptPath(plugin, index string) string {
+	return filepath.Join(p.InstallReceiptsPath(), index, plugin+constants.ManifestExtension)
 }
 
 // PluginVersionInstallPath returns the path to the specified version of specified
 // plugin.
 //
 // e.g. {PluginInstallPath}/{plugin}/{version}
-func (p Paths) PluginVersionInstallPath(plugin, version string) string {
-	return filepath.Join(p.InstallPath(), plugin, version)
+func (p Paths) PluginVersionInstallPath(index, plugin, version string) string {
+	return filepath.Join(p.InstallPath(), index, plugin, version)
 }
 
 // Realpath evaluates symbolic links. If the path is not a symbolic link, it

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -59,8 +59,13 @@ func (p Paths) BasePath() string { return p.base }
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath() string { return filepath.Join(p.base, "index") }
 
-// CustomIndicesPath returns the directory to the custom indices that have been added
-func (p Paths) CustomIndicesPath(dir string) string { return filepath.Join(p.base, "custom", dir) }
+// CustomIndexPath returns the directory to the custom indices that have been added
+func (p Paths) CustomIndexPath(dir string) string { return filepath.Join(p.base, "custom", dir) }
+
+// CustomIndexPluginsPath returns the plugins directory of the specified custom index
+func (p Paths) CustomIndexPluginsPath(index string) string {
+	return filepath.Join(p.base, "custom", index, "plugins")
+}
 
 // IndexPluginsPath returns the plugins directory of the index repository.
 //

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -63,16 +63,16 @@ func TestPaths(t *testing.T) {
 	if got, expected := p.InstallPath(), filepath.FromSlash("/foo/store"); got != expected {
 		t.Fatalf("InstallPath()=%s; expected=%s", got, expected)
 	}
-	if got, expected := p.PluginInstallPath("my-plugin"), filepath.FromSlash("/foo/store/my-plugin"); got != expected {
+	if got, expected := p.PluginInstallPath("my-plugin", ""), filepath.FromSlash("/foo/store/my-plugin"); got != expected {
 		t.Fatalf("PluginInstallPath()=%s; expected=%s", got, expected)
 	}
-	if got, expected := p.PluginVersionInstallPath("my-plugin", "v1"), filepath.FromSlash("/foo/store/my-plugin/v1"); got != expected {
+	if got, expected := p.PluginVersionInstallPath("", "my-plugin", "v1"), filepath.FromSlash("/foo/store/my-plugin/v1"); got != expected {
 		t.Fatalf("PluginVersionInstallPath()=%s; expected=%s", got, expected)
 	}
 	if got := p.InstallReceiptsPath(); !strings.HasSuffix(got, filepath.FromSlash("receipts")) {
 		t.Fatalf("InstallReceiptsPath()=%s; expected suffix 'receipts'", got)
 	}
-	if got := p.PluginInstallReceiptPath("my-plugin"); !strings.HasSuffix(got, filepath.FromSlash("receipts/my-plugin.yaml")) {
+	if got := p.PluginInstallReceiptPath("my-plugin", ""); !strings.HasSuffix(got, filepath.FromSlash("receipts/my-plugin.yaml")) {
 		t.Fatalf("PluginInstallReceiptPath()=%s; expected suffix 'receipts/my-plugin.yaml'", got)
 	}
 }

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -15,14 +15,15 @@
 package indexoperations
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/gitutil"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 type IndexConfig struct {
@@ -40,7 +41,7 @@ func (i IndexConfig) AddIndex(alias, uri string) error {
 
 func (i *IndexConfig) RemoveIndex(key string) error {
 	if _, ok := i.Indices[key]; !ok {
-		return fmt.Errorf("Must provide a valid index name to remove")
+		return errors.Errorf("must provide a valid index name to remove")
 	}
 	err := os.RemoveAll(environment.MustGetKrewPaths().CustomIndexPath(key))
 	if err != nil {
@@ -51,15 +52,15 @@ func (i *IndexConfig) RemoveIndex(key string) error {
 }
 
 func GetIndexConfig() (*IndexConfig, error) {
-	config, err := ioutil.ReadFile(environment.MustGetKrewPaths().IndexConfigPath() + "/indexconfig.yaml")
+	config, err := ioutil.ReadFile(environment.MustGetKrewPaths().IndexConfigPath() + "/indexconfig" + constants.ManifestExtension)
 	if os.IsNotExist(err) {
-		indexConfig := &IndexConfig{Indices: make(map[string]string, 0)}
+		indexConfig := &IndexConfig{Indices: make(map[string]string)}
 		err = createIndexConfigFile(indexConfig)
 		return indexConfig, err
 	} else if err != nil {
 		return nil, err
 	}
-	indexConfig := &IndexConfig{Indices: make(map[string]string, 0)}
+	indexConfig := &IndexConfig{Indices: make(map[string]string)}
 	err = yaml.Unmarshal(config, indexConfig)
 	if err != nil {
 		return nil, err
@@ -72,5 +73,5 @@ func createIndexConfigFile(indexConfig *IndexConfig) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(environment.MustGetKrewPaths().IndexConfigPath()+"/indexconfig.yaml", out, 0644)
+	return ioutil.WriteFile(environment.MustGetKrewPaths().IndexConfigPath()+"/indexconfig"+constants.ManifestExtension, out, 0644)
 }

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/internal/gitutil"
 )
 
 type IndexConfig struct {
@@ -30,6 +31,10 @@ type IndexConfig struct {
 
 func (i IndexConfig) AddIndex(alias, uri string) error {
 	i.Indices[alias] = uri
+	err := gitutil.EnsureUpdated(uri, environment.MustGetKrewPaths().CustomIndicesPath(alias))
+	if err != nil {
+		return err
+	}
 	return createIndexConfigFile(&i)
 }
 

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -19,7 +19,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/gitutil"

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -15,6 +15,7 @@
 package indexoperations
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -33,6 +34,9 @@ func (i IndexConfig) AddIndex(alias, uri string) error {
 }
 
 func (i *IndexConfig) RemoveIndex(key string) error {
+	if _, ok := i.Indices[key]; !ok {
+		return fmt.Errorf("Must provide a valid index name to remove")
+	}
 	delete(i.Indices, key)
 	return createIndexConfigFile(i)
 }

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -27,7 +27,7 @@ type IndexConfig struct {
 	Indices map[string]string `yaml:"indices"`
 }
 
-func (i IndexConfig) WriteIndexConfig(alias, uri string) error {
+func (i IndexConfig) AddIndex(alias, uri string) error {
 	i.Indices[alias] = uri
 	return createIndexConfigFile(&i)
 }

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -30,17 +30,21 @@ type IndexConfig struct {
 }
 
 func (i IndexConfig) AddIndex(alias, uri string) error {
-	i.Indices[alias] = uri
 	err := gitutil.EnsureUpdated(uri, environment.MustGetKrewPaths().CustomIndicesPath(alias))
 	if err != nil {
 		return err
 	}
+	i.Indices[alias] = uri
 	return createIndexConfigFile(&i)
 }
 
 func (i *IndexConfig) RemoveIndex(key string) error {
 	if _, ok := i.Indices[key]; !ok {
 		return fmt.Errorf("Must provide a valid index name to remove")
+	}
+	err := os.RemoveAll(environment.MustGetKrewPaths().CustomIndicesPath(key))
+	if err != nil {
+		return err
 	}
 	delete(i.Indices, key)
 	return createIndexConfigFile(i)

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -32,6 +32,11 @@ func (i IndexConfig) WriteIndexConfig(alias, uri string) error {
 	return createIndexConfigFile(&i)
 }
 
+func (i *IndexConfig) RemoveIndex(key string) error {
+	delete(i.Indices, key)
+	return createIndexConfigFile(i)
+}
+
 func GetIndexConfig() (*IndexConfig, error) {
 	config, err := ioutil.ReadFile(environment.MustGetKrewPaths().IndexConfigPath() + "/indexconfig.yaml")
 	if os.IsNotExist(err) {

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexoperations
+
+import (
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/yaml.v2"
+
+	"sigs.k8s.io/krew/internal/environment"
+)
+
+type IndexConfig struct {
+	Indices map[string]string `yaml:"indices"`
+}
+
+func (i IndexConfig) WriteIndexConfig(alias, uri string) error {
+	i.Indices[alias] = uri
+	return createIndexConfigFile(&i)
+}
+
+func GetIndexConfig() (*IndexConfig, error) {
+	config, err := ioutil.ReadFile(environment.MustGetKrewPaths().IndexConfigPath() + "/indexconfig.yaml")
+	if os.IsNotExist(err) {
+		indexConfig := &IndexConfig{Indices: make(map[string]string, 0)}
+		err = createIndexConfigFile(indexConfig)
+		return indexConfig, err
+	} else if err != nil {
+		return nil, err
+	}
+	indexConfig := &IndexConfig{Indices: make(map[string]string, 0)}
+	err = yaml.Unmarshal(config, indexConfig)
+	if err != nil {
+		return nil, err
+	}
+	return indexConfig, nil
+}
+
+func createIndexConfigFile(indexConfig *IndexConfig) error {
+	out, err := yaml.Marshal(indexConfig)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(environment.MustGetKrewPaths().IndexConfigPath()+"/indexconfig.yaml", out, 0644)
+}

--- a/internal/index/indexoperations/indexoperations.go
+++ b/internal/index/indexoperations/indexoperations.go
@@ -30,7 +30,7 @@ type IndexConfig struct {
 }
 
 func (i IndexConfig) AddIndex(alias, uri string) error {
-	err := gitutil.EnsureUpdated(uri, environment.MustGetKrewPaths().CustomIndicesPath(alias))
+	err := gitutil.EnsureUpdated(uri, environment.MustGetKrewPaths().CustomIndexPath(alias))
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (i *IndexConfig) RemoveIndex(key string) error {
 	if _, ok := i.Indices[key]; !ok {
 		return fmt.Errorf("Must provide a valid index name to remove")
 	}
-	err := os.RemoveAll(environment.MustGetKrewPaths().CustomIndicesPath(key))
+	err := os.RemoveAll(environment.MustGetKrewPaths().CustomIndexPath(key))
 	if err != nil {
 		return err
 	}

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -44,7 +44,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "manifest in receipts",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := paths.PluginInstallReceiptPath(pluginName)
+				path := paths.PluginInstallReceiptPath(pluginName, "")
 				tmpDir.Write(path, yamlBytes)
 			},
 		},
@@ -58,7 +58,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "invalid manifest in receipts",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := paths.PluginInstallReceiptPath(pluginName)
+				path := paths.PluginInstallReceiptPath(pluginName, "")
 				tmpDir.Write(path, []byte("invalid yaml file"))
 			},
 			shouldErr: true,

--- a/internal/installation/upgrade.go
+++ b/internal/installation/upgrade.go
@@ -30,7 +30,7 @@ import (
 // Upgrade will reinstall and delete the old plugin. The operation tries
 // to not get the plugin dir in a bad state if it fails during the process.
 func Upgrade(p environment.Paths, plugin index.Plugin) error {
-	installReceipt, err := receipt.Load(p.PluginInstallReceiptPath(plugin.Name))
+	installReceipt, err := receipt.Load(p.PluginInstallReceiptPath(plugin.Name, ""))
 	if err != nil {
 		return errors.Wrapf(err, "failed to load install receipt for plugin %q", plugin.Name)
 	}
@@ -66,7 +66,7 @@ func Upgrade(p environment.Paths, plugin index.Plugin) error {
 	klog.V(1).Infof("Plugin needs upgrade (%s < %s)", curv, newv)
 
 	klog.V(2).Infof("Upgrading install receipt for plugin %s", plugin.Name)
-	if err = receipt.Store(plugin, p.PluginInstallReceiptPath(plugin.Name)); err != nil {
+	if err = receipt.Store(plugin, p.PluginInstallReceiptPath(plugin.Name, "")); err != nil {
 		return errors.Wrap(err, "installation receipt could not be stored, uninstall may fail")
 	}
 
@@ -75,8 +75,7 @@ func Upgrade(p environment.Paths, plugin index.Plugin) error {
 	if err := install(installOperation{
 		pluginName: plugin.Name,
 		platform:   candidate,
-
-		installDir: p.PluginVersionInstallPath(plugin.Name, newVersion),
+		installDir: p.PluginVersionInstallPath("", plugin.Name, newVersion),
 		binDir:     p.BinPath(),
 	}, InstallOpts{}); err != nil {
 		return errors.Wrap(err, "failed to install new version")
@@ -98,6 +97,6 @@ func cleanupInstallation(p environment.Paths, plugin index.Plugin, oldVersion st
 		return nil
 	}
 
-	klog.V(1).Infof("Remove old plugin installation under %q", p.PluginVersionInstallPath(plugin.Name, oldVersion))
-	return os.RemoveAll(p.PluginVersionInstallPath(plugin.Name, oldVersion))
+	klog.V(1).Infof("Remove old plugin installation under %q", p.PluginVersionInstallPath("", plugin.Name, oldVersion))
+	return os.RemoveAll(p.PluginVersionInstallPath("", plugin.Name, oldVersion))
 }


### PR DESCRIPTION
I'm in the process of adding tests currently. I wanted to open the PR to write down the approach and maybe get some feedback. So here's a summary of the changes:
- added a new `index` subcommand
  - `kubectl krew index`: lists the configured custom indices
  - `kubectl krew index add custom-index https://github.com/custom/index.git`: adds a custom index with the name `custom-index`
  - `kubectl krew index remove custom-index`: removes the custom index with the name `custom-index`
- a file is stored at `$KREW_ROOT/indexconfig.yaml` that contains an object whose key/values are a user defined name and URI of the index being added
- custom indices are cloned to `$KREW_ROOT/custom/{index name}`
- plugins from custom indices are installed in `$KREW_ROOT/store/krew-indices/{index name}/{plugin}`
- plugin receipts for plugins installed from a custom index are stored `$KREW_ROOT/receipts/{index name}/{plugin}.yaml`
- plugins from custom indices need to be explicitly installed: `kubectl krew install custom-index/plugin` (this is similar to how its handled in [homebrew](https://docs.brew.sh/Taps); a follow up issue could be to handle plugin name collisions, but for this I only implemented allowing one or the other)
- list/search add plugins from custom indices to the end of the list:
```
$ kubectl krew list
PLUGIN           VERSION
ctx              v0.7.1
grep             v1.2.2
kudo             v0.10.0
ns               v0.7.1
whoami           v0.0.29
private/warp     v0.0.2

$ kubectl krew search
NAME                                    DESCRIPTION                                         INSTALLED
...
who-can                                 Shows who has RBAC permissions to access Kubern...  no
whoami                                  Show the subject that's currently authenticated...  yes
private/access-matrix                   Show an RBAC access matrix for server resources     no
private/auth-proxy                      Authentication proxy to a pod or service            no
private/warp                            Sync and execute local files in Pod                 yes
...
```
- update/upgrade have been modified to look in the correct directory for plugins
  - plugins from custom indices must be explicit when upgrading them specifically: `kubectl krew upgrade custom-index/plugin`
  - no arg upgrade will look in the correct directory for plugins that were installed from custom indices

I think that covers most things at a high level. I took a lot of ideas from `brew tap` in working on this feature. Its definitely a rough first draft and I would love to get some feedback. I chose to do things in certain ways to try to make it as backwards compatible as possible. This is a really important feature in order for me to use this at work (which I'd love to do).