### PR TITLE
GNU implementation's in scripts to support MacOS

### DIFF
--- a/hack/resolve-grep.sh
+++ b/hack/resolve-grep.sh
@@ -3,7 +3,7 @@ function resolvegrep () {
     if [[ $(whereis ggrep) -eq 0 ]]; then
       ggrep $@
     else
-      echo "GNU grep not found!"
+      echo "GNU grep not found - please install GNU coreutils from brew.sh (brew install coreutils)"
       exit 1
     fi
   else

--- a/hack/resolve-grep.sh
+++ b/hack/resolve-grep.sh
@@ -1,0 +1,12 @@
+function resolvegrep () {
+  if [[ $(uname) == "Darwin" ]]; then
+    if [[ $(whereis ggrep) -eq 0 ]]; then
+      ggrep $@
+    else
+      echo "GNU grep not found!"
+      exit 1
+    fi
+  else
+    grep $@
+  fi
+}

--- a/hack/resolve-link.sh
+++ b/hack/resolve-link.sh
@@ -1,0 +1,12 @@
+function resolvelink () {
+  if [[ $(uname) == "Darwin" ]]; then
+    if [[ $(whereis greadlink) -eq 0 ]]; then
+      greadlink -f $@
+    else
+      echo "GNU readlink not found"
+      exit 1
+    fi
+  else
+    readlink -f $@
+  fi
+}

--- a/hack/resolve-link.sh
+++ b/hack/resolve-link.sh
@@ -3,7 +3,7 @@ function resolvelink () {
     if [[ $(whereis greadlink) -eq 0 ]]; then
       greadlink -f $@
     else
-      echo "GNU readlink not found"
+      echo "GNU readlink not found - please install GNU coreutils from brew.sh (brew install coreutils)"
       exit 1
     fi
   else

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 [[ -n "${DEBUG:-}" ]] && set -x
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTDIR}/resolve-link.sh"
 BINDIR="${SCRIPTDIR}/../out/bin"
 goos="$(go env GOOS)"
 goarch="$(go env GOARCH)"
@@ -44,7 +45,7 @@ if [[ ! -e "${KREW_BINARY}" ]]; then
   echo >&2 "Could not find $KREW_BINARY. You need to build krew for ${goos}/${goarch} before running the integration tests."
   exit 1
 fi
-krew_binary_realpath="$(readlink -f "${KREW_BINARY}")"
+krew_binary_realpath="$(resolvelink "${KREW_BINARY}")"
 if [[ ! -x "${krew_binary_realpath}" ]]; then
   echo >&2 "krew binary at ${krew_binary_realpath} is not an executable"
   exit 1

--- a/hack/verify-code-patterns.sh
+++ b/hack/verify-code-patterns.sh
@@ -16,8 +16,11 @@
 
 set -euo pipefail
 
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTDIR}/resolve-grep.sh"
+
 # Disallow usage of ioutil.TempDir in tests in favor of testutil.
-out="$(grep --include '*_test.go' --exclude-dir 'vendor/' -EIrn 'ioutil.\TempDir' || true)"
+out="$(resolvegrep --include '*_test.go' --exclude-dir 'vendor/' -EIrn 'ioutil.\TempDir' || true)"
 if [[ -n "$out" ]]; then
   echo >&2 "You used ioutil.TempDir in tests, use 'testutil.NewTempDir()' instead:"
   echo >&2 "$out"
@@ -25,7 +28,7 @@ if [[ -n "$out" ]]; then
 fi
 
 # use code constant for ".yaml"
-out="$(grep --include '*.go' \
+out="$(resolvegrep --include '*.go' \
   --exclude "*_test.go" \
   --exclude 'constants.go' \
   --exclude-dir 'vendor/' \
@@ -37,7 +40,7 @@ if [[ -n "$out" ]]; then
 fi
 
 # Do not use glog/klog in test code
-out="$(grep --include '*_test.go' --exclude-dir 'vendor/' -EIrn '[kg]log\.' || true)"
+out="$(resolvegrep --include '*_test.go' --exclude-dir 'vendor/' -EIrn '[kg]log\.' || true)"
 if [[ -n "$out" ]]; then
   echo >&2 "You used glog or klog in tests, use 't.Logf' instead:"
   echo >&2 "$out"
@@ -45,7 +48,7 @@ if [[ -n "$out" ]]; then
 fi
 
 # Do not use fmt.Errorf as it does not start a stacktrace at error site
-out="$(grep --include '*.go' -EIrn 'fmt\.Errorf?' || true)"
+out="$(resolvegrep --include '*.go' -EIrn 'fmt\.Errorf?' || true)"
 if [[ -n "$out" ]]; then
   echo >&2 "You used fmt.Errorf; use pkg/errors.Errorf instead to preserve stack traces:"
   echo >&2 "$out"
@@ -53,7 +56,7 @@ if [[ -n "$out" ]]; then
 fi
 
 # Do not initialize index.{Plugin,Platform} structs in test code.
-out="$(grep --include '*_test.go' --exclude-dir 'vendor/' -EIrn '[^]](index\.)(Plugin|Platform){' || true)"
+out="$(resolvegrep --include '*_test.go' --exclude-dir 'vendor/' -EIrn '[^]](index\.)(Plugin|Platform){' || true)"
 if [[ -n "$out" ]]; then
   echo >&2 "Do not use index.Platform or index.Plugin structs directly in tests,"
   echo >&2 "use testutil.NewPlugin() or testutil.NewPlatform() instead:"

--- a/hack/verify-code-patterns.sh
+++ b/hack/verify-code-patterns.sh
@@ -64,3 +64,13 @@ if [[ -n "$out" ]]; then
   echo >&2 "$out"
   exit 1
 fi
+
+# Do not use readlink/stat/grep
+out="$(resolvegrep --include '*.sh' --exclude 'resolve-*.sh' -EIrn '((\$\{|\$\()(readlink|stat|grep))|(^(readlink|stat|grep))' || true)"
+if [[ -n "$out" ]]; then
+  echo >&2 "Do not use readlink, stat or grep in scripts,"
+  echo >&2 "use resolvelink or resolvegrep instead:"
+  echo >&2 "-----"
+  echo >&2 "$out"
+  exit 1
+fi

--- a/hack/verify-receipts-upgrade-migration.sh
+++ b/hack/verify-receipts-upgrade-migration.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 [[ -n "${DEBUG:-}" ]] && set -x
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source '${SCRIPTDIR}/resolve-link.sh'
 BINDIR="${SCRIPTDIR}/../out/bin"
 goos="$(go env GOOS)"
 goarch="$(go env GOARCH)"
@@ -56,7 +57,7 @@ patch_krew_bin() {
   new_binary="${2}"
 
   local old_binary
-  old_binary="$(readlink -f "${krew_root}/bin/kubectl-krew")"
+  old_binary="$(resolvelink "${krew_root}/bin/kubectl-krew")"
   cp -f "${new_binary}" "${old_binary}"
 }
 


### PR DESCRIPTION
#364 

MacOS grep/readlink/stat are insufficient for certain scripts so this wraps calls to those with a function that ensures the existence of and calls the GNU variant for Mac clients.