### PR TITLE
Add OS/Arch information in the krew version CLI output

### DIFF
--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/version"
 	"sigs.k8s.io/krew/pkg/constants"
 )
@@ -46,6 +47,7 @@ Remarks:
 			{"IndexPath", paths.IndexPath()},
 			{"InstallPath", paths.InstallPath()},
 			{"BinPath", paths.BinPath()},
+			{"DetectedPlatform", installation.OSArch().String()},
 		}
 		return printTable(os.Stdout, []string{"OPTION", "VALUE"}, conf)
 	},

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -68,6 +68,8 @@ func NewTest(t *testing.T) (*ITest, func()) {
 		env: []string{
 			fmt.Sprintf("KREW_ROOT=%s", tempDir.Root()),
 			fmt.Sprintf("PATH=%s", augmentPATH(t, binDir)),
+			"KREW_OS=linux",
+			"KREW_ARCH=amd64",
 		},
 		tempDir: tempDir,
 	}, cleanup


### PR DESCRIPTION
Add OS/Arch information in the krew version CLI output to help with diagnostics.
No unit test added since the function we are calling is already well tested.

Updated the KrewVersionTest integration test to convert the stdout to go map to leverage go-cmp for better test assertion. We now can report failure when new output is added to the `krew version` command.

Fixes #470