### PR TITLE
don't print security notice for krew itself

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -151,7 +151,7 @@ Remarks:
 					output += fmt.Sprintf("Caveats:\n%s\n", indent(plugin.Spec.Caveats))
 				}
 				fmt.Fprintln(os.Stderr, indent(output))
-				internal.PrintSecurityNotice()
+				internal.PrintSecurityNotice(plugin.Name)
 			}
 			if len(failed) > 0 {
 				return errors.Wrapf(returnErr, "failed to install some plugins: %+v", failed)

--- a/cmd/krew/cmd/internal/security_notice.go
+++ b/cmd/krew/cmd/internal/security_notice.go
@@ -19,13 +19,19 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
-const securityNotice = `You installed a plugin from the krew-index plugin repository.
+const securityNotice = `You installed plugin %q from the krew-index plugin repository.
    These plugins are not audited for security by the Krew maintainers.
    Run them at your own risk.`
 
-func PrintSecurityNotice() {
+func PrintSecurityNotice(plugin string) {
+	if plugin == constants.KrewPluginName {
+		return // do not warn for krew itself
+	}
 	boldRed := color.New(color.FgRed, color.Bold).SprintfFunc()
-	fmt.Fprintf(os.Stderr, "%s: %s\n", boldRed("WARNING"), securityNotice)
+	msg := fmt.Sprintf(securityNotice, plugin)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", boldRed("WARNING"), msg)
 }

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -88,7 +88,7 @@ kubectl krew upgrade foo bar"`,
 					return errors.Wrapf(err, "failed to upgrade plugin %q", name)
 				}
 				fmt.Fprintf(os.Stderr, "Upgraded plugin: %s\n", name)
-				internal.PrintSecurityNotice()
+				internal.PrintSecurityNotice(plugin.Name)
 			}
 			if nErrors > 0 {
 				fmt.Fprintf(os.Stderr, "WARNING: Some plugins failed to upgrade, check logs above.\n")


### PR DESCRIPTION
The security notice was primarily meant for plugins installed from
krew-index, but this doesn't apply to krew as Krew is a sub-project
of SIG CLI and its source code has proper code reviews and audit trail.

/assign @corneliusweig