### PR TITLE
Check whether PATH has been set up correctly

### DIFF
--- a/cmd/krew/cmd/internal/setup_check.go
+++ b/cmd/krew/cmd/internal/setup_check.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+
+	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/internal/installation"
+)
+
+const (
+	instructionWindows = `To be able to run kubectl plugins, you need to add the
+"%USERPROFILE%\.krew\bin" directory to your PATH environment variable
+and restart your shell.`
+	instructionUnixTemplate = `To be able to run kubectl plugins, you need to add
+the following to your %s
+
+and restart your shell.`
+	instructionZsh = `~/.zshrc:
+
+    export PATH="${PATH}:${HOME}/.krew/bin"`
+	instructionBash = `~/.bash_profile or ~/.bashrc:
+
+    export PATH="${PATH}:${HOME}/.krew/bin"`
+	instructionFish = `config.fish:
+
+    set -gx PATH $PATH $HOME/.krew/bin`
+	instructionGeneric = `~/.bash_profile, ~/.bashrc, or ~/.zshrc:
+
+    export PATH="${PATH}:${HOME}/.krew/bin"`
+)
+
+func IsBinDirInPATH(paths environment.Paths) bool {
+	// For the first run we don't want to show a warning.
+	_, err := os.Stat(paths.BasePath())
+	if err != nil {
+		klog.V(4).Info("Assuming this is the first run")
+		return os.IsNotExist(err)
+	}
+
+	binPath := paths.BinPath()
+	for _, dirInPATH := range filepath.SplitList(os.Getenv("PATH")) {
+		if dirInPATH == binPath {
+			return true
+		}
+	}
+	return false
+}
+
+func SetupInstructions() string {
+	if installation.IsWindows() {
+		return instructionWindows
+	}
+
+	var instruction string
+	switch shell := os.Getenv("SHELL"); {
+	case strings.HasSuffix(shell, "/zsh"):
+		instruction = instructionZsh
+	case strings.HasSuffix(shell, "/bash"):
+		instruction = instructionBash
+	case strings.HasSuffix(shell, "/fish"):
+		instruction = instructionFish
+	default:
+		instruction = instructionGeneric
+	}
+	return fmt.Sprintf(instructionUnixTemplate, instruction)
+}

--- a/cmd/krew/cmd/internal/setup_check_test.go
+++ b/cmd/krew/cmd/internal/setup_check_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/internal/testutil"
+)
+
+func TestIsBinDirInPATH_firstRun(t *testing.T) {
+	tempDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	paths := environment.NewPaths(tempDir.Path("does-not-exist"))
+	res := IsBinDirInPATH(paths)
+	if res == false {
+		t.Errorf("Expected positive result on first run")
+	}
+}
+
+func TestIsBinDirInPATH_secondRun(t *testing.T) {
+	tempDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+	if err := os.Mkdir(tempDir.Path("exists"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	paths := environment.NewPaths(tempDir.Path("exists"))
+	res := IsBinDirInPATH(paths)
+	if res == true {
+		t.Errorf("Expected negative result on second run")
+	}
+}
+
+func TestSetupInstructions_windows(t *testing.T) {
+	const instructionsContain = "add the\n\"%USERPROFILE%\\.krew\\bin\" directory to your PATH environment variable"
+	os.Setenv("KREW_OS", "windows")
+	defer func() { os.Unsetenv("KREW_OS") }()
+	instructions := SetupInstructions()
+	if !strings.Contains(instructions, instructionsContain) {
+		t.Errorf("expected %q\nto contain %q", instructions, instructionsContain)
+	}
+}
+
+func TestSetupInstructions_unix(t *testing.T) {
+	tests := []struct {
+		name                string
+		shell               string
+		instructionsContain string
+	}{
+		{
+			name:                "When the shell is zsh",
+			shell:               "/bin/zsh",
+			instructionsContain: "~/.zshrc",
+		},
+		{
+			name:                "When the shell is bash",
+			shell:               "/bin/bash",
+			instructionsContain: "~/.bash_profile or ~/.bashrc",
+		},
+		{
+			name:                "When the shell is fish",
+			shell:               "/bin/fish",
+			instructionsContain: "config.fish",
+		},
+		{
+			name:                "When the shell is unknown",
+			shell:               "other",
+			instructionsContain: "~/.bash_profile, ~/.bashrc, or ~/.zshrc",
+		},
+	}
+
+	// always set KREW_OS, so that tests succeed on windows
+	os.Setenv("KREW_OS", "linux")
+	defer func(origShell string) {
+		os.Unsetenv("KREW_OS")
+		os.Setenv("SHELL", origShell)
+	}(os.Getenv("SHELL"))
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			os.Setenv("SHELL", test.shell)
+			instructions := SetupInstructions()
+			if !strings.Contains(instructions, test.instructionsContain) {
+				tt.Errorf("expected %q\nto contain %q", instructions, test.instructionsContain)
+			}
+		})
+	}
+}

--- a/cmd/krew/cmd/internal/setup_check_test.go
+++ b/cmd/krew/cmd/internal/setup_check_test.go
@@ -30,20 +30,17 @@ func TestIsBinDirInPATH_firstRun(t *testing.T) {
 	paths := environment.NewPaths(tempDir.Path("does-not-exist"))
 	res := IsBinDirInPATH(paths)
 	if res == false {
-		t.Errorf("Expected positive result on first run")
+		t.Errorf("expected positive result on first run")
 	}
 }
 
 func TestIsBinDirInPATH_secondRun(t *testing.T) {
 	tempDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
-	if err := os.Mkdir(tempDir.Path("exists"), os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	paths := environment.NewPaths(tempDir.Path("exists"))
+	paths := environment.NewPaths(tempDir.Root())
 	res := IsBinDirInPATH(paths)
 	if res == true {
-		t.Errorf("Expected negative result on second run")
+		t.Errorf("expected negative result on second run")
 	}
 }
 


### PR DESCRIPTION
Fixes #485
Related https://github.com/Homebrew/homebrew-core/pull/49547

Homebrew refuses to add a post-install message for setting up
the PATH variable with krew's plugin store. Therefore we need
to check this on our side to warn users about an incomplete
setup. The goal is to
- print specific instructions for each shell/OS.
- not print the instructions when krew installs itself.

