### PR TITLE
Set new GOPATH env var to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,14 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     
+    - name: Add GOPATH
+      run: echo "::add-path::$(go env GOPATH)/bin"
+    
     - name: Install dependencies
       run: go mod download
     
     - name: Install gox
-      run: | 
-        export PATH=${PATH}:"$(go env GOPATH)/bin"
-        hack/install-gox.sh
+      run: hack/install-gox.sh
       
     - name: Verify code quality
       run: go mod tidy && git diff --no-patch --exit-code
@@ -48,9 +49,7 @@ jobs:
       run: go test -short -coverprofile=coverage.txt -covermode=atomic ./...
         
     - name: Make binaries && verify krew installation
-      run: |
-        export PATH=${PATH}:"$(go env GOPATH)/bin"
-        hack/make-all.sh
+      run: hack/make-all.sh
         
     - name: Ensure kubectl installed
       run: hack/ensure-kubectl-installed.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,7 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Add GOPATH/bin to PATH
-      # temporary fix
-      # see https://github.com/actions/setup-go/issues/14
-      run: |
-        set -euo pipefail
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+      run: export PATH=${PATH}:`go env GOPATH`/bin
     
     - name: Install dependencies
       run: go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
       run: hack/ensure-kubectl-installed.sh
         
     - name: Verify installation
-      run: hack/verify-installation.sh
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        hack/verify-installation.sh
     
     - name: Run integration tests
       run: hack/run-integration-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     
-    - name: Add GOPATH/bin to PATH
-      run: export PATH=${PATH}:`go env GOPATH`/bin
-    
     - name: Install dependencies
       run: go mod download
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Install gox
       run: | 
-        export PATH=${PATH}:`go env GOPATH`/bin
+        export PATH=${PATH}:"$(go env GOPATH)/bin"
         hack/install-gox.sh
       
     - name: Verify code quality
@@ -49,7 +49,7 @@ jobs:
         
     - name: Make binaries && verify krew installation
       run: |
-        export PATH=${PATH}:`go env GOPATH`/bin
+        export PATH=${PATH}:"$(go env GOPATH)/bin"
         hack/make-all.sh
         
     - name: Ensure kubectl installed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       run: go mod download
     
     - name: Install gox
-      run: hack/install-gox.sh
+      run: | 
+        export PATH=${PATH}:`go env GOPATH`/bin
+        hack/install-gox.sh
       
     - name: Verify code quality
       run: go mod tidy && git diff --no-patch --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,15 @@ jobs:
       run: go test -short -coverprofile=coverage.txt -covermode=atomic ./...
         
     - name: Make binaries && verify krew installation
-      run: hack/make-all.sh
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        hack/make-all.sh
         
     - name: Ensure kubectl installed
       run: hack/ensure-kubectl-installed.sh
         
     - name: Verify installation
-      run: |
-        export PATH=${PATH}:`go env GOPATH`/bin
-        hack/verify-installation.sh
+      run: hack/verify-installation.sh
     
     - name: Run integration tests
       run: hack/run-integration-tests.sh


### PR DESCRIPTION
This fixes the old way to set GOPATH to PATH.

This way is used by Minikube too.

I tested it and it works perfectly. [logs](https://github.com/alonyb/krew/runs/421428433?check_suite_focus=true)