### PR TITLE
Index migration

### DIFF
--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -146,7 +146,7 @@ func preRun(cmd *cobra.Command, _ []string) error {
 		}
 		if !isMigrated && cmd.Use != "index-upgrade" {
 			fmt.Fprintln(os.Stderr, "You need to perform a migration to continue using krew.\nPlease run `kubectl krew system index-upgrade`")
-			return errors.New("krew home outdated")
+			return errors.New("krew index outdated")
 		}
 	}
 

--- a/cmd/krew/cmd/system.go
+++ b/cmd/krew/cmd/system.go
@@ -15,8 +15,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
+	"sigs.k8s.io/krew/internal/indexmigration"
 	"sigs.k8s.io/krew/internal/receiptsmigration"
 )
 
@@ -50,7 +53,24 @@ This command will be removed without further notice from future versions of krew
 	PreRunE: ensureIndexUpdated,
 }
 
+var indexUpgradeCmd = &cobra.Command{
+	Use:   "index-upgrade",
+	Short: "Perform a migration of the krew index",
+	Long: `Krew became more awesome! To use the new features, you need to run this
+one-time migration, which will enable installing plugins from custom indexes.
+
+This command will be removed without further notice from future versions of krew.
+`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return indexmigration.Migrate(paths)
+	},
+}
+
 func init() {
+	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
+		systemCmd.AddCommand(indexUpgradeCmd)
+	}
 	systemCmd.AddCommand(receiptsUpgradeCmd)
 	rootCmd.AddCommand(systemCmd)
 }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -59,9 +59,6 @@ func (p Paths) BasePath() string { return p.base }
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath() string { return filepath.Join(p.base, "index") }
 
-// DefaultIndexPath returns the base directory where the default plugin index repository is cloned.
-func (p Paths) DefaultIndexPath() string { return filepath.Join(p.base, "index", "default") }
-
 // IndexPluginsPath returns the plugins directory of the index repository.
 //
 // e.g. {BasePath}/index/plugins/

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -59,6 +59,9 @@ func (p Paths) BasePath() string { return p.base }
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath() string { return filepath.Join(p.base, "index") }
 
+// DefaultIndexPath returns the base directory where the default plugin index repository is cloned.
+func (p Paths) DefaultIndexPath() string { return filepath.Join(p.base, "index", "default") }
+
 // IndexPluginsPath returns the plugins directory of the index repository.
 //
 // e.g. {BasePath}/index/plugins/

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -57,6 +57,6 @@ func Migrate(paths environment.Paths) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to clone index")
 	}
-	klog.Infof("Migration completed succesfully.")
+	klog.Infof("Migration completed successfully.")
 	return nil
 }

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/gitutil"
 	"sigs.k8s.io/krew/pkg/constants"
@@ -46,7 +47,7 @@ func Migrate(paths environment.Paths) error {
 		return nil
 	}
 
-	err := os.RemoveAll(paths.IndexPath())
+	err = os.RemoveAll(paths.IndexPath())
 	if err != nil {
 		return err
 	}

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexmigration
+
+import (
+	"os"
+
+	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/internal/gitutil"
+	"sigs.k8s.io/krew/pkg/constants"
+)
+
+// Done checks if the krew installation requires a migration to support multiple indexes.
+// A migration is necessary when the index directory doesn't contain a "default" directory.
+func Done(paths environment.Paths) (bool, error) {
+	f, err := os.Stat(paths.DefaultIndexPath())
+	if err == nil {
+		return f.IsDir(), nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// Migrate removes the index directory and then clones krew-index to the new default index path.
+func Migrate(paths environment.Paths) error {
+	err := os.RemoveAll(paths.IndexPath())
+	if err != nil {
+		return err
+	}
+	err = gitutil.EnsureCloned(constants.IndexURI, paths.DefaultIndexPath())
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -17,6 +17,7 @@ package indexmigration
 import (
 	"os"
 
+	"k8s.io/klog"
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/gitutil"
 	"sigs.k8s.io/krew/pkg/constants"
@@ -36,6 +37,15 @@ func Done(paths environment.Paths) (bool, error) {
 
 // Migrate removes the index directory and then clones krew-index to the new default index path.
 func Migrate(paths environment.Paths) error {
+	isMigrated, err := Done(paths)
+	if err != nil {
+		return err
+	}
+	if isMigrated {
+		klog.Infoln("Already migrated")
+		return nil
+	}
+
 	err := os.RemoveAll(paths.IndexPath())
 	if err != nil {
 		return err

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -57,5 +57,6 @@ func Migrate(paths environment.Paths) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to clone index")
 	}
+	klog.Infof("Migration completed succesfully.")
 	return nil
 }

--- a/internal/indexmigration/migration_test.go
+++ b/internal/indexmigration/migration_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexmigration
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/internal/testutil"
+)
+
+func TestIsMigrated(t *testing.T) {
+	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); !ok {
+		t.Skip("Set X_KREW_ENABLE_MULTI_INDEX variable to run this test")
+	}
+
+	tests := []struct {
+		name     string
+		dirPath  string
+		expected bool
+	}{
+		{
+			name:     "Already migrated",
+			dirPath:  "index/default",
+			expected: true,
+		},
+		{
+			name:     "Not migrated",
+			dirPath:  "index",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir, cleanup := testutil.NewTempDir(t)
+			defer cleanup()
+
+			_ = os.MkdirAll(tmpDir.Path(test.dirPath), os.ModePerm)
+
+			newPaths := environment.NewPaths(tmpDir.Root())
+			actual, err := Done(newPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual != test.expected {
+				t.Errorf("Expected %v but found %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/indexmigration/migration_test.go
+++ b/internal/indexmigration/migration_test.go
@@ -34,7 +34,7 @@ func TestIsMigrated(t *testing.T) {
 	}{
 		{
 			name:     "Already migrated",
-			dirPath:  "index",
+			dirPath:  "index/default/.git",
 			expected: true,
 		},
 		{

--- a/internal/indexmigration/migration_test.go
+++ b/internal/indexmigration/migration_test.go
@@ -34,12 +34,12 @@ func TestIsMigrated(t *testing.T) {
 	}{
 		{
 			name:     "Already migrated",
-			dirPath:  "index/default",
+			dirPath:  "index",
 			expected: true,
 		},
 		{
 			name:     "Not migrated",
-			dirPath:  "index",
+			dirPath:  "index/.git",
 			expected: false,
 		},
 	}
@@ -49,7 +49,10 @@ func TestIsMigrated(t *testing.T) {
 			tmpDir, cleanup := testutil.NewTempDir(t)
 			defer cleanup()
 
-			_ = os.MkdirAll(tmpDir.Path(test.dirPath), os.ModePerm)
+			err := os.MkdirAll(tmpDir.Path(test.dirPath), os.ModePerm)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			newPaths := environment.NewPaths(tmpDir.Root())
 			actual, err := Done(newPaths)


### PR DESCRIPTION
This only adds the migration code to change the directory structure that will be needed to support custom indexes. The other changes will be in subsequent PRs.

I'm using the existence of the ~~`index/default/`~~`index/.git` directory to indicate whether or not a migration needs to be performed.

Related issue: #483 
<!-- For proposed features, make sure there's an issue it's discussed first -->
