### PR TITLE
Refactor existing index path functions to support multiple indexes later on

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -91,7 +91,7 @@ Remarks:
 
 			var install []index.Plugin
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(""), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath("default"), name)
 				if err != nil {
 					if os.IsNotExist(err) {
 						return errors.Errorf("plugin %q does not exist in the plugin index", name)

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -91,7 +91,7 @@ Remarks:
 
 			var install []index.Plugin
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(""), name)
 				if err != nil {
 					if os.IsNotExist(err) {
 						return errors.Errorf("plugin %q does not exist in the plugin index", name)

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/krew/cmd/krew/cmd/internal"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
+	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
 
@@ -91,7 +92,7 @@ Remarks:
 
 			var install []index.Plugin
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath("default"), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(constants.DefaultIndexName), name)
 				if err != nil {
 					if os.IsNotExist(err) {
 						return errors.Errorf("plugin %q does not exist in the plugin index", name)

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -199,7 +199,7 @@ func cleanupStaleKrewInstallations() error {
 }
 
 func checkIndex(_ *cobra.Command, _ []string) error {
-	if ok, err := gitutil.IsGitCloned(paths.IndexPath()); err != nil {
+	if ok, err := gitutil.IsGitCloned(paths.IndexPath("")); err != nil {
 		return errors.Wrap(err, "failed to check local index git repository")
 	} else if !ok {
 		return errors.New(`krew local plugin index is not initialized (run "kubectl krew update")`)

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -139,7 +139,7 @@ func preRun(cmd *cobra.Command, _ []string) error {
 		return errors.New("krew home outdated")
 	}
 
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexFlag); ok {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
 		isMigrated, err = indexmigration.Done(paths)
 		if err != nil {
 			return errors.Wrap(err, "error getting file info")

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -139,7 +139,7 @@ func preRun(cmd *cobra.Command, _ []string) error {
 		return errors.New("krew home outdated")
 	}
 
-	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexFlag); ok {
 		isMigrated, err = indexmigration.Done(paths)
 		if err != nil {
 			return errors.Wrap(err, "error getting file info")

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -199,7 +199,7 @@ func cleanupStaleKrewInstallations() error {
 }
 
 func checkIndex(_ *cobra.Command, _ []string) error {
-	if ok, err := gitutil.IsGitCloned(paths.IndexPath("default")); err != nil {
+	if ok, err := gitutil.IsGitCloned(paths.IndexPath(constants.DefaultIndexName)); err != nil {
 		return errors.Wrap(err, "failed to check local index git repository")
 	} else if !ok {
 		return errors.New(`krew local plugin index is not initialized (run "kubectl krew update")`)

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -199,7 +199,7 @@ func cleanupStaleKrewInstallations() error {
 }
 
 func checkIndex(_ *cobra.Command, _ []string) error {
-	if ok, err := gitutil.IsGitCloned(paths.IndexPath("")); err != nil {
+	if ok, err := gitutil.IsGitCloned(paths.IndexPath("default")); err != nil {
 		return errors.Wrap(err, "failed to check local index git repository")
 	} else if !ok {
 		return errors.New(`krew local plugin index is not initialized (run "kubectl krew update")`)

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -42,7 +42,7 @@ Examples:
   To fuzzy search plugins with a keyword:
     kubectl krew search KEYWORD`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		plugins, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(""))
+		plugins, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath("default"))
 		if err != nil {
 			return errors.Wrap(err, "failed to load the list of plugins from the index")
 		}

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
+	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
 
@@ -42,7 +43,7 @@ Examples:
   To fuzzy search plugins with a keyword:
     kubectl krew search KEYWORD`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		plugins, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath("default"))
+		plugins, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(constants.DefaultIndexName))
 		if err != nil {
 			return errors.Wrap(err, "failed to load the list of plugins from the index")
 		}

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -42,7 +42,7 @@ Examples:
   To fuzzy search plugins with a keyword:
     kubectl krew search KEYWORD`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		plugins, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath())
+		plugins, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(""))
 		if err != nil {
 			return errors.Wrap(err, "failed to load the list of plugins from the index")
 		}

--- a/cmd/krew/cmd/system.go
+++ b/cmd/krew/cmd/system.go
@@ -69,7 +69,7 @@ This command will be removed without further notice from future versions of krew
 }
 
 func init() {
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexFlag); ok {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
 		systemCmd.AddCommand(indexUpgradeCmd)
 	}
 	systemCmd.AddCommand(receiptsUpgradeCmd)

--- a/cmd/krew/cmd/system.go
+++ b/cmd/krew/cmd/system.go
@@ -21,6 +21,7 @@ import (
 
 	"sigs.k8s.io/krew/internal/indexmigration"
 	"sigs.k8s.io/krew/internal/receiptsmigration"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 // todo(corneliusweig) remove migration code with v0.4
@@ -68,7 +69,7 @@ This command will be removed without further notice from future versions of krew
 }
 
 func init() {
-	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexFlag); ok {
 		systemCmd.AddCommand(indexUpgradeCmd)
 	}
 	systemCmd.AddCommand(receiptsUpgradeCmd)

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -103,10 +103,10 @@ func showUpdatedPlugins(out io.Writer, preUpdate, posUpdate []index.Plugin, inst
 }
 
 func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
-	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(""))
+	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath("default"))
 
-	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath(""))
-	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath("")); err != nil {
+	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath("default"))
+	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath("default")); err != nil {
 		return errors.Wrap(err, "failed to update the local index")
 	}
 	fmt.Fprintln(os.Stderr, "Updated the local copy of plugin index.")
@@ -115,7 +115,7 @@ func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	posUpdateIndex, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(""))
+	posUpdateIndex, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath("default"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load plugin index after update")
 	}

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -103,10 +103,10 @@ func showUpdatedPlugins(out io.Writer, preUpdate, posUpdate []index.Plugin, inst
 }
 
 func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
-	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath("default"))
+	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(constants.DefaultIndexName))
 
-	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath("default"))
-	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath("default")); err != nil {
+	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath(constants.DefaultIndexName))
+	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath(constants.DefaultIndexName)); err != nil {
 		return errors.Wrap(err, "failed to update the local index")
 	}
 	fmt.Fprintln(os.Stderr, "Updated the local copy of plugin index.")
@@ -115,7 +115,7 @@ func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	posUpdateIndex, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath("default"))
+	posUpdateIndex, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(constants.DefaultIndexName))
 	if err != nil {
 		return errors.Wrap(err, "failed to load plugin index after update")
 	}

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -103,10 +103,10 @@ func showUpdatedPlugins(out io.Writer, preUpdate, posUpdate []index.Plugin, inst
 }
 
 func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
-	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath())
+	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(""))
 
-	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath())
-	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath()); err != nil {
+	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath(""))
+	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath("")); err != nil {
 		return errors.Wrap(err, "failed to update the local index")
 	}
 	fmt.Fprintln(os.Stderr, "Updated the local copy of plugin index.")
@@ -115,7 +115,7 @@ func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	posUpdateIndex, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath())
+	posUpdateIndex, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(""))
 	if err != nil {
 		return errors.Wrap(err, "failed to load plugin index after update")
 	}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -62,7 +62,7 @@ kubectl krew upgrade foo bar"`,
 
 			var nErrors int
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(""), name)
 				if err != nil {
 					if !os.IsNotExist(err) {
 						return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/krew/cmd/krew/cmd/internal"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func init() {
@@ -62,7 +63,7 @@ kubectl krew upgrade foo bar"`,
 
 			var nErrors int
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath("default"), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(constants.DefaultIndexName), name)
 				if err != nil {
 					if !os.IsNotExist(err) {
 						return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -62,7 +62,7 @@ kubectl krew upgrade foo bar"`,
 
 			var nErrors int
 			for _, name := range pluginNames {
-				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(""), name)
+				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath("default"), name)
 				if err != nil {
 					if !os.IsNotExist(err) {
 						return errors.Wrapf(err, "failed to load the plugin manifest for plugin %s", name)

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -44,7 +44,7 @@ Remarks:
 			{"GitCommit", version.GitCommit()},
 			{"IndexURI", constants.IndexURI},
 			{"BasePath", paths.BasePath()},
-			{"IndexPath", paths.IndexPath()},
+			{"IndexPath", paths.IndexPath("")},
 			{"InstallPath", paths.InstallPath()},
 			{"BinPath", paths.BinPath()},
 			{"DetectedPlatform", installation.OSArch().String()},

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -44,7 +44,7 @@ Remarks:
 			{"GitCommit", version.GitCommit()},
 			{"IndexURI", constants.IndexURI},
 			{"BasePath", paths.BasePath()},
-			{"IndexPath", paths.IndexPath("default")},
+			{"IndexPath", paths.IndexPath(constants.DefaultIndexName)},
 			{"InstallPath", paths.InstallPath()},
 			{"BinPath", paths.BinPath()},
 			{"DetectedPlatform", installation.OSArch().String()},

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -44,7 +44,7 @@ Remarks:
 			{"GitCommit", version.GitCommit()},
 			{"IndexURI", constants.IndexURI},
 			{"BasePath", paths.BasePath()},
-			{"IndexPath", paths.IndexPath("")},
+			{"IndexPath", paths.IndexPath("default")},
 			{"InstallPath", paths.InstallPath()},
 			{"BinPath", paths.BinPath()},
 			{"DetectedPlatform", installation.OSArch().String()},

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -64,7 +64,7 @@ func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 	defer cleanup()
 
 	test = test.WithIndex()
-	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath()
+	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath("")
 	localManifest := filepath.Join(manifestDir, validPlugin+constants.ManifestExtension)
 	if _, err := os.Stat(localManifest); err != nil {
 		t.Fatalf("could not read local manifest file at %s: %v", localManifest, err)

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -64,7 +64,7 @@ func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 	defer cleanup()
 
 	test = test.WithIndex()
-	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath("default")
+	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath(constants.DefaultIndexName)
 	localManifest := filepath.Join(manifestDir, validPlugin+constants.ManifestExtension)
 	if _, err := os.Stat(localManifest); err != nil {
 		t.Fatalf("could not read local manifest file at %s: %v", localManifest, err)

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -64,7 +64,7 @@ func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 	defer cleanup()
 
 	test = test.WithIndex()
-	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath("")
+	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath("default")
 	localManifest := filepath.Join(manifestDir, validPlugin+constants.ManifestExtension)
 	if _, err := os.Stat(localManifest); err != nil {
 		t.Fatalf("could not read local manifest file at %s: %v", localManifest, err)

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -56,7 +56,7 @@ func TestKrewUpdateListsNewPlugins(t *testing.T) {
 
 	test = test.WithIndex()
 
-	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(), validPlugin+constants.ManifestExtension)
+	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(""), validPlugin+constants.ManifestExtension)
 	if err := os.Remove(pluginManifest); err != nil {
 		t.Fatalf("failed to delete manifest of an existing plugin: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestKrewUpdateListsUpgradesAvailable(t *testing.T) {
 	test = test.WithIndex()
 
 	// set version of some manifests to v0.0.0
-	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(), validPlugin+constants.ManifestExtension)
+	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(""), validPlugin+constants.ManifestExtension)
 	modifyManifestVersion(t, pluginManifest, "v0.0.0")
 
 	test.Krew("install", validPlugin, "--no-update-index").RunOrFail()  // has updates available

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -56,7 +56,7 @@ func TestKrewUpdateListsNewPlugins(t *testing.T) {
 
 	test = test.WithIndex()
 
-	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath("default"), validPlugin+constants.ManifestExtension)
+	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(constants.DefaultIndexName), validPlugin+constants.ManifestExtension)
 	if err := os.Remove(pluginManifest); err != nil {
 		t.Fatalf("failed to delete manifest of an existing plugin: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestKrewUpdateListsUpgradesAvailable(t *testing.T) {
 	test = test.WithIndex()
 
 	// set version of some manifests to v0.0.0
-	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath("default"), validPlugin+constants.ManifestExtension)
+	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(constants.DefaultIndexName), validPlugin+constants.ManifestExtension)
 	modifyManifestVersion(t, pluginManifest, "v0.0.0")
 
 	test.Krew("install", validPlugin, "--no-update-index").RunOrFail()  // has updates available

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -56,7 +56,7 @@ func TestKrewUpdateListsNewPlugins(t *testing.T) {
 
 	test = test.WithIndex()
 
-	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(""), validPlugin+constants.ManifestExtension)
+	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath("default"), validPlugin+constants.ManifestExtension)
 	if err := os.Remove(pluginManifest); err != nil {
 		t.Fatalf("failed to delete manifest of an existing plugin: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestKrewUpdateListsUpgradesAvailable(t *testing.T) {
 	test = test.WithIndex()
 
 	// set version of some manifests to v0.0.0
-	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath(""), validPlugin+constants.ManifestExtension)
+	pluginManifest := filepath.Join(environment.NewPaths(test.Root()).IndexPluginsPath("default"), validPlugin+constants.ManifestExtension)
 	modifyManifestVersion(t, pluginManifest, "v0.0.0")
 
 	test.Krew("install", validPlugin, "--no-update-index").RunOrFail()  // has updates available

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -57,12 +57,22 @@ func (p Paths) BasePath() string { return p.base }
 // IndexPath returns the base directory where plugin index repository is cloned.
 //
 // e.g. {BasePath}/index/
-func (p Paths) IndexPath() string { return filepath.Join(p.base, "index") }
+func (p Paths) IndexPath(name string) string {
+	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
+		if name == "" {
+			return filepath.Join(p.base, "index", constants.DefaultIndexName)
+		}
+		return filepath.Join(p.base, "index", name)
+	}
+	return filepath.Join(p.base, "index")
+}
 
 // IndexPluginsPath returns the plugins directory of the index repository.
 //
 // e.g. {BasePath}/index/plugins/
-func (p Paths) IndexPluginsPath() string { return filepath.Join(p.base, "index", "plugins") }
+func (p Paths) IndexPluginsPath(name string) string {
+	return filepath.Join(p.IndexPath(name), "plugins")
+}
 
 // InstallReceiptsPath returns the base directory where plugin receipts are stored.
 //

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -65,9 +65,6 @@ func (p Paths) IndexBase() string {
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath(name string) string {
 	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
-		if name == "" {
-			return filepath.Join(p.base, "index", constants.DefaultIndexName)
-		}
 		return filepath.Join(p.base, "index", name)
 	}
 	return p.IndexBase()

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -54,7 +54,8 @@ func NewPaths(base string) Paths {
 // BasePath returns krew base directory.
 func (p Paths) BasePath() string { return p.base }
 
-// IndexBase returns the krew index directory.
+// IndexBase returns the krew index directory. This directory contains the default
+// index and custom ones.
 func (p Paths) IndexBase() string {
 	return filepath.Join(p.base, "index")
 }
@@ -63,7 +64,7 @@ func (p Paths) IndexBase() string {
 //
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath(name string) string {
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexFlag); ok {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
 		if name == "" {
 			return filepath.Join(p.base, "index", constants.DefaultIndexName)
 		}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -60,9 +60,10 @@ func (p Paths) IndexBase() string {
 	return filepath.Join(p.base, "index")
 }
 
-// IndexPath returns the base directory where plugin index repository is cloned.
-//
-// e.g. {BasePath}/index/
+// IndexPath returns the directory where a plugin index repository is cloned.
+// When constants.EnableMultiIndexSwitch var is unset it just returns the krew
+// index base.
+// e.g. {BasePath}/index/default or {BasePath}/index
 func (p Paths) IndexPath(name string) string {
 	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
 		return filepath.Join(p.base, "index", name)
@@ -70,9 +71,10 @@ func (p Paths) IndexPath(name string) string {
 	return p.IndexBase()
 }
 
-// IndexPluginsPath returns the plugins directory of the index repository.
-//
-// e.g. {BasePath}/index/plugins/
+// IndexPluginsPath returns the plugins directory of an index repository.
+// When constants.EnableMultiIndexSwitch var is unset it just returns the old
+// structure krew-index plugins.
+// e.g. {BasePath}/index/default/plugins/ or {BasePath}/index/plugins/
 func (p Paths) IndexPluginsPath(name string) string {
 	return filepath.Join(p.IndexPath(name), "plugins")
 }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -54,17 +54,22 @@ func NewPaths(base string) Paths {
 // BasePath returns krew base directory.
 func (p Paths) BasePath() string { return p.base }
 
+// IndexBase returns the krew index directory.
+func (p Paths) IndexBase() string {
+	return filepath.Join(p.base, "index")
+}
+
 // IndexPath returns the base directory where plugin index repository is cloned.
 //
 // e.g. {BasePath}/index/
 func (p Paths) IndexPath(name string) string {
-	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexFlag); ok {
 		if name == "" {
 			return filepath.Join(p.base, "index", constants.DefaultIndexName)
 		}
 		return filepath.Join(p.base, "index", name)
 	}
-	return filepath.Join(p.base, "index")
+	return p.IndexBase()
 }
 
 // IndexPluginsPath returns the plugins directory of the index repository.

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -50,55 +50,57 @@ func TestPaths(t *testing.T) {
 	base := filepath.FromSlash("/foo")
 	p := NewPaths(base)
 	if got := p.BasePath(); got != base {
-		t.Fatalf("BasePath()=%s; expected=%s", got, base)
+		t.Errorf("BasePath()=%s; expected=%s", got, base)
 	}
 	if got, expected := p.BinPath(), filepath.FromSlash("/foo/bin"); got != expected {
-		t.Fatalf("BinPath()=%s; expected=%s", got, expected)
+		t.Errorf("BinPath()=%s; expected=%s", got, expected)
 	}
 
-	// Test index path functions with EnableMultiIndexFlag
-	os.Setenv(constants.EnableMultiIndexFlag, "1")
-	if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index/default"); got != expected {
-		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
-		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
-		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
-		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-	}
-	// Test index path functions without EnableMultiIndexFlag
-	os.Unsetenv(constants.EnableMultiIndexFlag)
-	if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
-		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index"); got != expected {
-		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
-		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/plugins"); got != expected {
-		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-	}
+	t.Run("with EnableMultiIndexSwitch", func(t *testing.T) {
+		os.Setenv(constants.EnableMultiIndexSwitch, "1")
+		defer os.Unsetenv(constants.EnableMultiIndexSwitch)
+		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index/default"); got != expected {
+			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
+			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
+	})
+	t.Run("without EnableMultiIndexSwitch", func(t *testing.T) {
+		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
+			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index"); got != expected {
+			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
+	})
 
 	if got, expected := p.InstallPath(), filepath.FromSlash("/foo/store"); got != expected {
-		t.Fatalf("InstallPath()=%s; expected=%s", got, expected)
+		t.Errorf("InstallPath()=%s; expected=%s", got, expected)
 	}
 	if got, expected := p.PluginInstallPath("my-plugin"), filepath.FromSlash("/foo/store/my-plugin"); got != expected {
-		t.Fatalf("PluginInstallPath()=%s; expected=%s", got, expected)
+		t.Errorf("PluginInstallPath()=%s; expected=%s", got, expected)
 	}
 	if got, expected := p.PluginVersionInstallPath("my-plugin", "v1"), filepath.FromSlash("/foo/store/my-plugin/v1"); got != expected {
-		t.Fatalf("PluginVersionInstallPath()=%s; expected=%s", got, expected)
+		t.Errorf("PluginVersionInstallPath()=%s; expected=%s", got, expected)
 	}
 	if got := p.InstallReceiptsPath(); !strings.HasSuffix(got, filepath.FromSlash("receipts")) {
-		t.Fatalf("InstallReceiptsPath()=%s; expected suffix 'receipts'", got)
+		t.Errorf("InstallReceiptsPath()=%s; expected suffix 'receipts'", got)
 	}
 	if got := p.PluginInstallReceiptPath("my-plugin"); !strings.HasSuffix(got, filepath.FromSlash("receipts/my-plugin.yaml")) {
-		t.Fatalf("PluginInstallReceiptPath()=%s; expected suffix 'receipts/my-plugin.yaml'", got)
+		t.Errorf("PluginInstallReceiptPath()=%s; expected suffix 'receipts/my-plugin.yaml'", got)
 	}
 }
 

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -59,31 +59,31 @@ func TestPaths(t *testing.T) {
 	t.Run("with EnableMultiIndexSwitch", func(t *testing.T) {
 		os.Setenv(constants.EnableMultiIndexSwitch, "1")
 		defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index/default"); got != expected {
-			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPath("default"), filepath.FromSlash("/foo/index/default"); got != expected {
+			t.Errorf("IndexPath(\"default\")=%s; expected=%s", got, expected)
 		}
-		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPluginsPath("default"), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"default\")=%s; expected=%s", got, expected)
 		}
 		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
-			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+			t.Errorf("IndexPath(\"test\")=%s; expected=%s", got, expected)
 		}
 		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+			t.Errorf("IndexPluginsPath(\"test\")=%s; expected=%s", got, expected)
 		}
 	})
 	t.Run("without EnableMultiIndexSwitch", func(t *testing.T) {
-		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
-			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPath("default"), filepath.FromSlash("/foo/index"); got != expected {
+			t.Errorf("IndexPath(\"default\")=%s; expected=%s", got, expected)
 		}
 		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index"); got != expected {
-			t.Errorf("IndexPath()=%s; expected=%s", got, expected)
+			t.Errorf("IndexPath(\"test\")=%s; expected=%s", got, expected)
 		}
-		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPluginsPath("default"), filepath.FromSlash("/foo/index/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"default\")=%s; expected=%s", got, expected)
 		}
 		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+			t.Errorf("IndexPluginsPath(\"test\")=%s; expected=%s", got, expected)
 		}
 	})
 

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -59,31 +59,19 @@ func TestPaths(t *testing.T) {
 	t.Run("with EnableMultiIndexSwitch", func(t *testing.T) {
 		os.Setenv(constants.EnableMultiIndexSwitch, "1")
 		defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-		if got, expected := p.IndexPath("default"), filepath.FromSlash("/foo/index/default"); got != expected {
-			t.Errorf("IndexPath(\"default\")=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/default"); got != expected {
+			t.Errorf("IndexPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
 		}
-		if got, expected := p.IndexPluginsPath("default"), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"default\")=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
-			t.Errorf("IndexPath(\"test\")=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"test\")=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPluginsPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
 		}
 	})
 	t.Run("without EnableMultiIndexSwitch", func(t *testing.T) {
-		if got, expected := p.IndexPath("default"), filepath.FromSlash("/foo/index"); got != expected {
-			t.Errorf("IndexPath(\"default\")=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index"); got != expected {
+			t.Errorf("IndexPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
 		}
-		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index"); got != expected {
-			t.Errorf("IndexPath(\"test\")=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPluginsPath("default"), filepath.FromSlash("/foo/index/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"default\")=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"test\")=%s; expected=%s", got, expected)
+		if got, expected := p.IndexPluginsPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/plugins"); got != expected {
+			t.Errorf("IndexPluginsPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
 		}
 	})
 

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -54,11 +54,26 @@ func TestPaths(t *testing.T) {
 	if got, expected := p.BinPath(), filepath.FromSlash("/foo/bin"); got != expected {
 		t.Fatalf("BinPath()=%s; expected=%s", got, expected)
 	}
-	if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
-		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-	}
-	if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
-		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
+		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index/default"); got != expected {
+			t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
+			t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
+			t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
+			t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
+	} else {
+		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
+			t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
+		}
+		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
+			t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+		}
 	}
 	if got, expected := p.InstallPath(), filepath.FromSlash("/foo/store"); got != expected {
 		t.Fatalf("InstallPath()=%s; expected=%s", got, expected)

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	"sigs.k8s.io/krew/internal/testutil"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
@@ -54,27 +55,36 @@ func TestPaths(t *testing.T) {
 	if got, expected := p.BinPath(), filepath.FromSlash("/foo/bin"); got != expected {
 		t.Fatalf("BinPath()=%s; expected=%s", got, expected)
 	}
-	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); ok {
-		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index/default"); got != expected {
-			t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
-			t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
-			t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
-			t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-		}
-	} else {
-		if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
-			t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
-		}
-		if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
-			t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
-		}
+
+	// Test index path functions with EnableMultiIndexFlag
+	os.Setenv(constants.EnableMultiIndexFlag, "1")
+	if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index/default"); got != expected {
+		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
 	}
+	if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
+		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+	}
+	if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index/test"); got != expected {
+		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
+	}
+	if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/test/plugins"); got != expected {
+		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+	}
+	// Test index path functions without EnableMultiIndexFlag
+	os.Unsetenv(constants.EnableMultiIndexFlag)
+	if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
+		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
+	}
+	if got, expected := p.IndexPath("test"), filepath.FromSlash("/foo/index"); got != expected {
+		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
+	}
+	if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
+		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+	}
+	if got, expected := p.IndexPluginsPath("test"), filepath.FromSlash("/foo/index/plugins"); got != expected {
+		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
+	}
+
 	if got, expected := p.InstallPath(), filepath.FromSlash("/foo/store"); got != expected {
 		t.Fatalf("InstallPath()=%s; expected=%s", got, expected)
 	}

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -54,11 +54,11 @@ func TestPaths(t *testing.T) {
 	if got, expected := p.BinPath(), filepath.FromSlash("/foo/bin"); got != expected {
 		t.Fatalf("BinPath()=%s; expected=%s", got, expected)
 	}
-	if got, expected := p.IndexPath(), filepath.FromSlash("/foo/index"); got != expected {
+	if got, expected := p.IndexPath(""), filepath.FromSlash("/foo/index"); got != expected {
 		t.Fatalf("IndexPath()=%s; expected=%s", got, expected)
 	}
-	if got, expected := p.IndexPluginsPath(), filepath.FromSlash("/foo/index/plugins"); got != expected {
-		t.Fatalf("IndexPluginsPath()=%s; expected=%s", got, expected)
+	if got, expected := p.IndexPluginsPath(""), filepath.FromSlash("/foo/index/plugins"); got != expected {
+		t.Fatalf("IndexPluginsPath(\"\")=%s; expected=%s", got, expected)
 	}
 	if got, expected := p.InstallPath(), filepath.FromSlash("/foo/store"); got != expected {
 		t.Fatalf("InstallPath()=%s; expected=%s", got, expected)

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -27,7 +27,7 @@ import (
 // Done checks if the krew installation requires a migration to support multiple indexes.
 // A migration is necessary when the index directory contains a ".git" directory.
 func Done(paths environment.Paths) (bool, error) {
-	_, err := os.Stat(filepath.Join(paths.IndexPath(), ".git"))
+	_, err := os.Stat(filepath.Join(paths.IndexBase(), ".git"))
 	if err != nil && os.IsNotExist(err) {
 		return true, nil
 	}

--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -44,9 +44,9 @@ func Migrate(paths environment.Paths) error {
 		klog.V(2).Infoln("Already migrated")
 		return nil
 	}
-	indexPath := paths.IndexPath()
+	indexPath := paths.IndexBase()
 	tmpPath := filepath.Join(paths.BasePath(), "tmp_index_migration")
-	newPath := filepath.Join(paths.IndexPath(), "default")
+	newPath := filepath.Join(paths.IndexBase(), "default")
 
 	if err := os.Rename(indexPath, tmpPath); err != nil {
 		return errors.Wrapf(err, "could not move index directory %q to temporary location %q", indexPath, tmpPath)

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
+	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
 
@@ -40,5 +41,5 @@ func LoadManifestFromReceiptOrIndex(p environment.Paths, name string) (index.Plu
 	}
 
 	klog.V(3).Infof("Plugin manifest for %q not found in the receipts dir", name)
-	return indexscanner.LoadPluginByName(p.IndexPluginsPath("default"), name)
+	return indexscanner.LoadPluginByName(p.IndexPluginsPath(constants.DefaultIndexName), name)
 }

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -40,5 +40,5 @@ func LoadManifestFromReceiptOrIndex(p environment.Paths, name string) (index.Plu
 	}
 
 	klog.V(3).Infof("Plugin manifest for %q not found in the receipts dir", name)
-	return indexscanner.LoadPluginByName(p.IndexPluginsPath(), name)
+	return indexscanner.LoadPluginByName(p.IndexPluginsPath(""), name)
 }

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -40,5 +40,5 @@ func LoadManifestFromReceiptOrIndex(p environment.Paths, name string) (index.Plu
 	}
 
 	klog.V(3).Infof("Plugin manifest for %q not found in the receipts dir", name)
-	return indexscanner.LoadPluginByName(p.IndexPluginsPath(""), name)
+	return indexscanner.LoadPluginByName(p.IndexPluginsPath("default"), name)
 }

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -51,7 +51,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "manifest in index",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := filepath.Join(paths.IndexPluginsPath(), pluginName+".yaml")
+				path := filepath.Join(paths.IndexPluginsPath(""), pluginName+".yaml")
 				tmpDir.Write(path, yamlBytes)
 			},
 		},
@@ -66,7 +66,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "invalid manifest in index",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := filepath.Join(paths.IndexPluginsPath(), pluginName+".yaml")
+				path := filepath.Join(paths.IndexPluginsPath(""), pluginName+".yaml")
 				tmpDir.Write(path, []byte("invalid yaml file"))
 			},
 			shouldErr: true,

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -51,7 +51,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "manifest in index",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := filepath.Join(paths.IndexPluginsPath(""), pluginName+".yaml")
+				path := filepath.Join(paths.IndexPluginsPath("default"), pluginName+".yaml")
 				tmpDir.Write(path, yamlBytes)
 			},
 		},
@@ -66,7 +66,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "invalid manifest in index",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := filepath.Join(paths.IndexPluginsPath(""), pluginName+".yaml")
+				path := filepath.Join(paths.IndexPluginsPath("default"), pluginName+".yaml")
 				tmpDir.Write(path, []byte("invalid yaml file"))
 			},
 			shouldErr: true,

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -24,6 +24,7 @@ import (
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/testutil"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
@@ -51,7 +52,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "manifest in index",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := filepath.Join(paths.IndexPluginsPath("default"), pluginName+".yaml")
+				path := filepath.Join(paths.IndexPluginsPath(constants.DefaultIndexName), pluginName+".yaml")
 				tmpDir.Write(path, yamlBytes)
 			},
 		},
@@ -66,7 +67,7 @@ func TestLoadManifestFromReceiptOrIndex(t *testing.T) {
 		{
 			name: "invalid manifest in index",
 			prepare: func(paths environment.Paths, tmpDir *testutil.TempDir) {
-				path := filepath.Join(paths.IndexPluginsPath("default"), pluginName+".yaml")
+				path := filepath.Join(paths.IndexPluginsPath(constants.DefaultIndexName), pluginName+".yaml")
 				tmpDir.Write(path, []byte("invalid yaml file"))
 			},
 			shouldErr: true,

--- a/internal/receiptsmigration/migration.go
+++ b/internal/receiptsmigration/migration.go
@@ -76,7 +76,7 @@ func Migrate(newPaths environment.Paths) error {
 	klog.Infoln("These plugins will be reinstalled: ", installed)
 
 	// krew must be skipped by the normal migration logic
-	if err := copyKrewManifest(newPaths.IndexPluginsPath(""), newPaths.InstallReceiptsPath()); err != nil {
+	if err := copyKrewManifest(newPaths.IndexPluginsPath("default"), newPaths.InstallReceiptsPath()); err != nil {
 		return errors.Wrapf(err, "failed to copy krew manifest")
 	}
 
@@ -138,7 +138,7 @@ func getPluginsToReinstall(oldPaths oldenvironment.Paths, newPaths environment.P
 
 // isAvailableInIndex checks that the given plugin is available in the index
 func isAvailableInIndex(paths environment.Paths, plugin string) bool {
-	pluginYaml := filepath.Join(paths.IndexPluginsPath(""), plugin+constants.ManifestExtension)
+	pluginYaml := filepath.Join(paths.IndexPluginsPath("default"), plugin+constants.ManifestExtension)
 	_, err := os.Lstat(pluginYaml)
 	return err == nil
 }

--- a/internal/receiptsmigration/migration.go
+++ b/internal/receiptsmigration/migration.go
@@ -76,7 +76,7 @@ func Migrate(newPaths environment.Paths) error {
 	klog.Infoln("These plugins will be reinstalled: ", installed)
 
 	// krew must be skipped by the normal migration logic
-	if err := copyKrewManifest(newPaths.IndexPluginsPath("default"), newPaths.InstallReceiptsPath()); err != nil {
+	if err := copyKrewManifest(newPaths.IndexPluginsPath(constants.DefaultIndexName), newPaths.InstallReceiptsPath()); err != nil {
 		return errors.Wrapf(err, "failed to copy krew manifest")
 	}
 
@@ -138,7 +138,7 @@ func getPluginsToReinstall(oldPaths oldenvironment.Paths, newPaths environment.P
 
 // isAvailableInIndex checks that the given plugin is available in the index
 func isAvailableInIndex(paths environment.Paths, plugin string) bool {
-	pluginYaml := filepath.Join(paths.IndexPluginsPath("default"), plugin+constants.ManifestExtension)
+	pluginYaml := filepath.Join(paths.IndexPluginsPath(constants.DefaultIndexName), plugin+constants.ManifestExtension)
 	_, err := os.Lstat(pluginYaml)
 	return err == nil
 }

--- a/internal/receiptsmigration/migration.go
+++ b/internal/receiptsmigration/migration.go
@@ -76,7 +76,7 @@ func Migrate(newPaths environment.Paths) error {
 	klog.Infoln("These plugins will be reinstalled: ", installed)
 
 	// krew must be skipped by the normal migration logic
-	if err := copyKrewManifest(newPaths.IndexPluginsPath(), newPaths.InstallReceiptsPath()); err != nil {
+	if err := copyKrewManifest(newPaths.IndexPluginsPath(""), newPaths.InstallReceiptsPath()); err != nil {
 		return errors.Wrapf(err, "failed to copy krew manifest")
 	}
 
@@ -138,7 +138,7 @@ func getPluginsToReinstall(oldPaths oldenvironment.Paths, newPaths environment.P
 
 // isAvailableInIndex checks that the given plugin is available in the index
 func isAvailableInIndex(paths environment.Paths, plugin string) bool {
-	pluginYaml := filepath.Join(paths.IndexPluginsPath(), plugin+constants.ManifestExtension)
+	pluginYaml := filepath.Join(paths.IndexPluginsPath(""), plugin+constants.ManifestExtension)
 	_, err := os.Lstat(pluginYaml)
 	return err == nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,7 +24,7 @@ const (
 	IndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
 	// DefaultIndexName is a magic string that's used for a plugin name specified without an index.
 	DefaultIndexName = "default"
-	// EnableMultiIndexFlag is the name of the environment variable that needs to be set to use
+	// EnableMultiIndexSwitch is the name of the environment variable that needs to be set to use
 	// the features around multiple indexes (this will be removed later on).
-	EnableMultiIndexFlag = "X_KREW_ENABLE_MULTI_INDEX"
+	EnableMultiIndexSwitch = "X_KREW_ENABLE_MULTI_INDEX"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,4 +24,7 @@ const (
 	IndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
 	// DefaultIndexName is a magic string that's used for a plugin name specified without an index.
 	DefaultIndexName = "default"
+	// EnableMultiIndexFlag is the name of the environment variable that needs to be set to use
+	// the features around multiple indexes (this will be removed later on).
+	EnableMultiIndexFlag = "X_KREW_ENABLE_MULTI_INDEX"
 )


### PR DESCRIPTION
Add a name parameter to the index path functions (and behind the `X_KREW_ENABLE_MULTI_INDEX` variable) to return the path for the specified index, with "default" being implicit. Refactor the existing calls to use an empty string for now that gets ignored when the variable is unset.

The integration tests fail when `X_KREW_ENABLE_MULTI_INDEX` is set since the other functionality doesn't exist yet.

Related issue: #483 
<!-- For proposed features, make sure there's an issue it's discussed first -->
