### PR TITLE
Simpler migration without external dependency

### DIFF
--- a/internal/indexmigration/migration.go
+++ b/internal/indexmigration/migration.go
@@ -30,9 +30,7 @@ import (
 // A migration is necessary when the index directory contains a ".git" directory.
 func Done(paths environment.Paths) (bool, error) {
 	_, err := os.Stat(filepath.Join(paths.IndexPath(), ".git"))
-	if err == nil {
-		return false, nil
-	} else if os.IsNotExist(err) {
+	if err != nil && os.IsNotExist(err) {
 		return true, nil
 	}
 	return false, err

--- a/internal/indexmigration/migration_test.go
+++ b/internal/indexmigration/migration_test.go
@@ -61,3 +61,32 @@ func TestIsMigrated(t *testing.T) {
 		})
 	}
 }
+
+func TestMigrate(t *testing.T) {
+	var tests = []struct {
+		name   string
+		gitDir string
+	}{
+		{name: "migration is necessary", gitDir: "index/.git"},
+		{name: "no migration is necessary", gitDir: "index/default/.git"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, cleanup := testutil.NewTempDir(t)
+			defer cleanup()
+
+			tmpDir.Write(tt.gitDir, nil)
+
+			newPaths := environment.NewPaths(tmpDir.Root())
+			err := Migrate(newPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			done, err := Done(newPaths)
+			if err != nil || !done {
+				t.Errorf("expected migration to be done: %s", err)
+			}
+		})
+	}
+}

--- a/internal/indexmigration/migration_test.go
+++ b/internal/indexmigration/migration_test.go
@@ -23,10 +23,6 @@ import (
 )
 
 func TestIsMigrated(t *testing.T) {
-	if _, ok := os.LookupEnv("X_KREW_ENABLE_MULTI_INDEX"); !ok {
-		t.Skip("Set X_KREW_ENABLE_MULTI_INDEX variable to run this test")
-	}
-
 	tests := []struct {
 		name     string
 		dirPath  string


### PR DESCRIPTION
This migrates the krew home to the new layout without an external dependency.
Related issue: #505

Also see https://github.com/kubernetes-sigs/krew/pull/505#discussion_r382856984
<!-- For proposed features, make sure there's an issue it's discussed first -->

cc @chriskim06 