### PR TITLE
Use static URL to download assets from latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check out the list of [kubectl plugins available on krew][list] or just run
     ```sh
     (
       set -x; cd "$(mktemp -d)" &&
-      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/v0.3.4/krew.{tar.gz,yaml}" &&
+      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.{tar.gz,yaml}" &&
       tar zxvf krew.tar.gz &&
       KREW=./krew-"$(uname | tr '[:upper:]' '[:lower:]')_amd64" &&
       "$KREW" install --manifest=krew.yaml --archive=krew.tar.gz &&
@@ -78,7 +78,7 @@ Check out the list of [kubectl plugins available on krew][list] or just run
     ```fish
     begin
       set -x; set temp_dir (mktemp -d); cd "$temp_dir" &&
-      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/v0.3.4/krew.{tar.gz,yaml}" &&
+      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.{tar.gz,yaml}" &&
       tar zxvf krew.tar.gz &&
       set KREWNAME krew-(uname | tr '[:upper:]' '[:lower:]')_amd64 &&
       ./$KREWNAME install \

--- a/docs/RELEASING_KREW.md
+++ b/docs/RELEASING_KREW.md
@@ -32,11 +32,26 @@ Krew tags versions starting with `v`. Example: `v0.2.0-rc.1`.
     TAG=v0.3.2-rc.1 # <- change this
     ```
 
+1. **Create a release commit:**
+
+       git commit -am "Release ${TAG:?TAG required}" --allow-empty
+
+1. **Push PR and merge changes**: The repository hooks forbid direct pushes to
+   master, so the changes from the previous step need to be pushed and merged
+   as a regular PR.
+
+       git push origin master
+
+   (Only repository administrators can directly push to master branch.)
+
+1. **Wait until the build succeeds:** Wait for CI to show green for the
+   build of the commit you just pushed to master branch.
+
 1. **Tag the release:**
 
     ```sh
     git fetch origin
-    git reset --hard origin/master
+    git reset --hard origin/master    # when the previous merge is done
     release_notes="$(TAG=$TAG hack/make-release-notes.sh)"
     git tag -a "${TAG:?TAG required}" -m "${release_notes}"
     ```

--- a/docs/RELEASING_KREW.md
+++ b/docs/RELEASING_KREW.md
@@ -32,29 +32,11 @@ Krew tags versions starting with `v`. Example: `v0.2.0-rc.1`.
     TAG=v0.3.2-rc.1 # <- change this
     ```
 
-1. **Update installation instructions:** Version number is hardcoded in
-   `README.md`.
-
-1. **Commit the changes back:**
-
-       git commit -am "Release ${TAG:?TAG required}"
-
-1. **Push PR and merge changes**: The repository hooks forbid direct pushes to
-   master, so the changes from the previous step need to be pushed and merged
-   as a regular PR.
-
-       git push origin master
-
-   (Only repository administrators can directly push to master branch.)
-
-1. **Wait until the build succeeds:** Wait for Travis CI to show green for the
-   build for the commit you just pushed to master branch.
-
 1. **Tag the release:**
 
     ```sh
     git fetch origin
-    git reset --hard origin/master    # when the previous merge is done
+    git reset --hard origin/master
     release_notes="$(TAG=$TAG hack/make-release-notes.sh)"
     git tag -a "${TAG:?TAG required}" -m "${release_notes}"
     ```


### PR DESCRIPTION
This also simplifies the release process for krew, because the version
number does not need to be updated when releasing a new version.

Fixes #...
Related issue: #...
<!-- For proposed features, make sure there's an issue it's discussed first -->
