### PR TITLE
Consider HTTP status for more meaningful errors

### DIFF
--- a/cmd/krew/cmd/internal/fetch_tag.go
+++ b/cmd/krew/cmd/internal/fetch_tag.go
@@ -37,6 +37,9 @@ func FetchLatestTag() (string, error) {
 		return "", errors.Wrapf(err, "could not GET the latest release")
 	}
 	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", errors.Errorf("expected HTTP status 200 OK, got %s", response.Status)
+	}
 
 	var res struct {
 		Tag string `json:"tag_name"`

--- a/cmd/krew/cmd/internal/fetch_tag_test.go
+++ b/cmd/krew/cmd/internal/fetch_tag_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func Test_fetchLatestTag_GitHubAPI(t *testing.T) {
+	// TODO(corneliusweig) re-enable once Travis CI is discontinued
+	t.Skip("skipping GitHub API test due to instability on travis")
 	tag, err := FetchLatestTag()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
The krew CI has quite a few problems on travis, supposedly due to
API quota violation. For more meaningful errors, we now consider the
HTTP status code of the GitHub API response.

Fixes #516
<!-- For proposed features, make sure there's an issue it's discussed first -->
