### PR TITLE
site: robots.txt

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -1,6 +1,7 @@
 title: "Krew – kubectl plugin manager"
 baseURL: "https://krew.sigs.k8s.io/"
 languageCode: "en-us"
+enableRobotsTXT: true
 disableKinds:
 - taxonomy
 - taxonomyTerm

--- a/site/layouts/robots.txt
+++ b/site/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+{{ if ne ( getenv "HUGO_ENV" ) "production" -}}
+Disallow: /
+{{- end -}}


### PR DESCRIPTION
Prevent Netlify preview environments from being indexed by search bots.

If HUGO_ENV!=production, we return Disallow:/