### PR TITLE
site: add gitinfo and edit links to footer

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@ HUGO_VERSION = "0.65.1"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+command = "hugo --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
-command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+command = "hugo --buildFuture -b $DEPLOY_PRIME_URL"

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -1,6 +1,7 @@
 title: "Krew – kubectl plugin manager"
 baseURL: "https://krew.sigs.k8s.io/"
 languageCode: "en-us"
+enableGitInfo: true
 disableKinds:
 - taxonomy
 - taxonomyTerm

--- a/site/layouts/404.html
+++ b/site/layouts/404.html
@@ -8,4 +8,4 @@
 
 <a href=" {{ "/" }}  " class="btn btn-lg btn-primary">&larr; Home</a>
 
-{{ partial "footer.html" }}
+{{ partial "footer.html" . }}

--- a/site/layouts/docs/section.html
+++ b/site/layouts/docs/section.html
@@ -19,4 +19,4 @@
         {{ partial "backbutton.html" .}}
     {{ end }}
 </article>
-{{ partial "footer.html" }}
+{{ partial "footer.html" . }}

--- a/site/layouts/docs/single.html
+++ b/site/layouts/docs/single.html
@@ -9,4 +9,4 @@
     </article>
 
 {{ partial "backbutton.html" .}}
-{{ partial "footer.html" }}
+{{ partial "footer.html" . }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -11,4 +11,4 @@
 
 </article>
 
-{{ partial "footer.html" }}
+{{ partial "footer.html" . }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,12 +1,25 @@
 
-        <footer class="text-muted">
+        <footer class="text-muted small">
             <hr/>
-            <small>
-                &copy; {{ now.Format "2006"}} The Kubernetes Authors.
-                Krew documentation is distributed under
-                <a target="_blank" href='https://creativecommons.org/licenses/by/4.0/' class='text-muted'>CC-BY-4.0</a>.<br/>
-                Krew is a Kubernetes <a href="https://github.com/kubernetes/community/blob/master/sig-cli/README.md#cli-special-interest-group" target="_blank">SIG CLI</a> project.
-            </small>
+            &copy; {{ now.Format "2006"}} The Kubernetes Authors.
+            Krew is a Kubernetes
+                <a href="https://github.com/kubernetes/community/blob/master/sig-cli/README.md#cli-special-interest-group" target="_blank" class="text-info">
+                    SIG CLI</a> project.
+                <p>
+                    {{ with .File }}
+                        <a href="http://sigs.k8s.io/krew/site/content/{{- .File.Path -}}" target="_blank" class="text-info">
+                        Edit Page</a>
+                    {{ end }}
+
+                    {{ if .GitInfo }}
+                    <strong>&middot;</strong>
+                    Built from commit
+                    <a href="https://github.com/kubernetes-sigs/krew/commit/{{- .GitInfo.Hash -}}"
+                        target="_blank" class="text-muted">
+                        {{- .GitInfo.AbbreviatedHash -}}
+                    </a>.
+                    {{ end}}
+                </p>
         </footer>
         </div>
     </div><!-- .container -->


### PR DESCRIPTION


* pass page variables to footer

* use .GitInfo and .File variables to show something like this in the footer
      for each page:

        [Edit Page] - Built from commit [xxxx]

* enableGitInfo both locally and on Netlify builds