### PR TITLE
site: add toc snippet for long articles

### DIFF
--- a/site/content/docs/developer-guide/develop/best-practices.md
+++ b/site/content/docs/developer-guide/develop/best-practices.md
@@ -4,6 +4,8 @@ slug: best-practices
 weight: 300
 ---
 
+{{< toc >}}
+
 This guide lists practices to use while developing `kubectl` plugins. Before
 submitting your plugin to Krew, please review these
 
@@ -11,7 +13,7 @@ While Krew project does not enforce any strict guidelines about how a plugin
 works, using some of these practices can help your plugin work for more users
 and behave more predictably.
 
-### Choosing a language
+## Choosing a language
 
 Most `kubectl` plugins are written in Go or as bash scripts.
 
@@ -21,7 +23,7 @@ If you are planning to write a plugin with Go, check out:
 - [cli-runtime]: Provides packages to share code with `kubectl` for printing output or [sharing command-line options][cli-opts]
 - [sample-cli-plugin]: An example plugin implementation in Go
 
-### Consistency with kubectl {#kubectl-options}
+## Consistency with kubectl {#kubectl-options}
 
 Krew does not try to impose any rules in terms of the shape of your plugin.
 
@@ -39,7 +41,7 @@ Furthermore, by using the [genericclioptions][cli-opts] package (Go), you can
 support the global command-line flags listed in `kubectl options` (e.g.
 `--kubeconfig`, `--context` and many others) in your plugins.
 
-### Import authentication plugins (Go) {#auth-plugins}
+## Import authentication plugins (Go) {#auth-plugins}
 
 By default, plugins that use [client-go]
 cannot authenticate to Kubernetes clusters on many cloud providers. To overcome

--- a/site/content/docs/developer-guide/plugin-manifest.md
+++ b/site/content/docs/developer-guide/plugin-manifest.md
@@ -4,6 +4,8 @@ slug: plugin-manifest
 weight: 150
 ---
 
+{{<toc>}}
+
 Each Krew plugin has a "plugin manifest", which is a YAML file that describes
 the plugin, how it can be downloaded and installed on a machine.
 
@@ -14,7 +16,7 @@ It is **highly recommended** you look at [example plugin manifests]({{< ref
 "example-plugin-manifests.md" >}}) to copy from an existing plugin and adapt to
 your needs instead of learning everything in this page.
 
-#### Sample plugin manifest
+## Sample plugin manifest
 
 Here's a sample manifest file that installs a bash-based plugin that supports
 only Linux and macOS:
@@ -58,7 +60,7 @@ spec:
     bin: restart.sh
 ```
 
-#### Documentation fields
+## Documentation fields
 
 - `shortDescription:` (required): Punchline for your plugin. It should not exceed
   a few words (to be properly shown in `kubectl krew search` output). **Avoid**
@@ -75,7 +77,7 @@ spec:
 
   `caveats` are shown to the user after installing the plugin for the first time.
 
-#### Specifying plugin download options
+## Specifying plugin download options
 
 Krew plugins must be packaged as `.zip` or `.tar.gz` archives, and should
 accessible to download from user’s machine. The relevant fields are:
@@ -90,7 +92,7 @@ accessible to download from user’s machine. The relevant fields are:
     ...
 ```
 
-#### Specifying platform-specific instructions
+## Specifying platform-specific instructions
 
 Krew makes it possible to install the same plugin on different operating systems
 (like `windows`, `darwin` (macOS), and `linux`) and different architectures
@@ -132,7 +134,7 @@ architectures using the keys `os` and `arch` respectively.
 The possible values for `os` and `arch`  come from the Go runtime. Run
 `go tool dist list` to see all possible platforms and architectures.
 
-#### Specifying files to install
+## Specifying files to install
 
 Each operating system may require a different set of files from the archive to
 be installed.
@@ -174,7 +176,7 @@ the files `from` the archive `to` the installation destination.
   As a result of this operation, the copied out files will preserve their
   directory structure in the extracted directory.
 
-#### Specifying plugin executable
+## Specifying plugin executable
 
 Each `platform` field requires a path to the plugin executable in the plugin's
 installation directory.

--- a/site/layouts/shortcodes/toc.html
+++ b/site/layouts/shortcodes/toc.html
@@ -1,0 +1,4 @@
+<aside class="blockquote toc pt-2 pb-1 mt-1 mb-3 mx-0">
+<header class="h5">In this article:</header>
+{{ .Page.TableOfContents }}
+</aside>

--- a/site/static/css/style.css
+++ b/site/static/css/style.css
@@ -2,7 +2,7 @@ div.top-level-container {
     max-width: 960px;
 }
 
-blockquote {
+blockquote, .blockquote {
     margin-left: 12px;
     color: #555;
     max-width: 520px;
@@ -16,6 +16,7 @@ article h1, article h2, article h3, article h4 {
 
 pre {
     padding: 12px;
+    overflow-y: scroll;
 }
 
 .noselect {
@@ -38,4 +39,9 @@ pre .cmdoutput {
 .lead {
     letter-spacing: -0.4px;
     font-weight: 300;
+}
+
+article aside.toc {
+    background-color: #f8f8f8;;
+    font-size: 1rem;
 }


### PR DESCRIPTION
Make it easier to grasp long docs pages by adding a Table of Contents snippet.

Example:
- https://deploy-preview-534--kubernetes-sigs-krew.netlify.com/docs/developer-guide/develop/best-practices/
- https://deploy-preview-534--kubernetes-sigs-krew.netlify.com/docs/developer-guide/plugin-manifest/