### PR TITLE
Add index list command

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -27,8 +27,8 @@ import (
 // indexCmd represents the index command
 var indexCmd = &cobra.Command{
 	Use:    "index",
-	Short:  "Add, remove, and list indexes",
-	Long:   "Perform krew index commands such as adding, removing, and listing indexes.",
+	Short:  "Manage custom plugin indexes",
+	Long:   "Manage which repositories are used to discover and install plugins from.",
 	Args:   cobra.NoArgs,
 	Hidden: true, // TODO(chriskim06) remove this once multi-index is enabled
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -29,7 +29,7 @@ import (
 var indexCmd = &cobra.Command{
 	Use:    "index",
 	Short:  "Perform krew index commands",
-	Long:   "Show a list of installed kubectl plugins and their versions.",
+	Long:   "Perform krew index commands such as adding and removing indexes.",
 	Args:   cobra.NoArgs,
 	Hidden: true, // remove this once multi-index is enabled
 }
@@ -40,7 +40,7 @@ var indexListCmd = &cobra.Command{
 	Long: `Print a list of configured indexes.
 
 This command prints a list of indexes. It shows the name and the remote URL for
-each configured index.`,
+each configured index in table format.`,
 	Args: cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		dirs, err := ioutil.ReadDir(paths.IndexBase())

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/krew/pkg/constants"
+)
+
+// listCmd represents the list command
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Perform krew index commands",
+	Long: `Show a list of installed kubectl plugins and their versions.
+
+Remarks:
+  Redirecting the output of this command to a program or file will only print
+  the names of the plugins installed. This output can be piped back to the
+  "install" command.`,
+	Args:   cobra.NoArgs,
+	Hidden: true,
+}
+
+var indexListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured indexes",
+	Long:  `Print a list of configured indexes.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dirs, err := ioutil.ReadDir(paths.IndexBase())
+		if err != nil {
+			return errors.Wrapf(err, "failed to read directory %s", paths.IndexBase())
+		}
+		for _, dir := range dirs {
+			fmt.Fprintln(os.Stdout, dir.Name())
+		}
+		return nil
+	},
+}
+
+func init() {
+	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
+		indexCmd.AddCommand(indexListCmd)
+		rootCmd.AddCommand(indexCmd)
+	}
+}

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -56,14 +56,13 @@ each configured index in table format.`,
 			}
 			rows = append(rows, []string{indexName, remote})
 		}
-		rows = sortByFirstColumn(rows)
 		return printTable(os.Stdout, []string{"INDEX", "URL"}, rows)
 	},
 }
 
 func init() {
 	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
-		rootCmd.AddCommand(indexCmd)
 		indexCmd.AddCommand(indexListCmd)
+		rootCmd.AddCommand(indexCmd)
 	}
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
-// listCmd represents the list command
+// indexCmd represents the index command
 var indexCmd = &cobra.Command{
 	Use:    "index",
 	Short:  "Perform krew index commands",

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -72,8 +72,7 @@ func EnsureUpdated(uri, destinationPath string) error {
 
 // GetRemoteURL returns the url of the remote origin
 func GetRemoteURL(dir string) (string, error) {
-	remote, err := Exec(dir, "config", "--get", "remote.origin.url")
-	return strings.TrimRight(remote, "\n\r"), err
+	return Exec(dir, "config", "--get", "remote.origin.url")
 }
 
 func Exec(pwd string, args ...string) (string, error) {
@@ -89,5 +88,5 @@ func Exec(pwd string, args ...string) (string, error) {
 	if err := cmd.Run(); err != nil {
 		return "", errors.Wrapf(err, "command execution failure, output=%q", buf.String())
 	}
-	return buf.String(), nil
+	return strings.TrimSpace(buf.String()), nil
 }

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -31,7 +31,7 @@ func EnsureCloned(uri, destinationPath string) error {
 	if ok, err := IsGitCloned(destinationPath); err != nil {
 		return err
 	} else if !ok {
-		_, err = exec("", "clone", "-v", uri, destinationPath)
+		_, err = Exec("", "clone", "-v", uri, destinationPath)
 		return err
 	}
 	return nil
@@ -50,15 +50,15 @@ func IsGitCloned(gitPath string) (bool, error) {
 // and also will create a pristine working directory by removing
 // untracked files and directories.
 func updateAndCleanUntracked(destinationPath string) error {
-	if _, err := exec(destinationPath, "fetch", "-v"); err != nil {
+	if _, err := Exec(destinationPath, "fetch", "-v"); err != nil {
 		return errors.Wrapf(err, "fetch index at %q failed", destinationPath)
 	}
 
-	if _, err := exec(destinationPath, "reset", "--hard", "@{upstream}"); err != nil {
+	if _, err := Exec(destinationPath, "reset", "--hard", "@{upstream}"); err != nil {
 		return errors.Wrapf(err, "reset index at %q failed", destinationPath)
 	}
 
-	_, err := exec(destinationPath, "clean", "-xfd")
+	_, err := Exec(destinationPath, "clean", "-xfd")
 	return errors.Wrapf(err, "clean index at %q failed", destinationPath)
 }
 
@@ -72,10 +72,11 @@ func EnsureUpdated(uri, destinationPath string) error {
 
 // GetRemoteURL returns the url of the remote origin
 func GetRemoteURL(dir string) (string, error) {
-	return exec(dir, "config", "--get", "remote.origin.url")
+	remote, err := Exec(dir, "config", "--get", "remote.origin.url")
+	return strings.TrimRight(remote, "\n\r"), err
 }
 
-func exec(pwd string, args ...string) (string, error) {
+func Exec(pwd string, args ...string) (string, error) {
 	klog.V(4).Infof("Going to run git %s", strings.Join(args, " "))
 	cmd := osexec.Command("git", args...)
 	cmd.Dir = pwd

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexoperations
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/krew/internal/gitutil"
+)
+
+// Index describes the name and URL of a configured index.
+type Index struct {
+	Name string
+	URL  string
+}
+
+// ListIndexes returns a slice of Index objects. The path argument is used as
+// the base path of the index.
+func ListIndexes(path string) ([]Index, error) {
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read directory %s", path)
+	}
+
+	indexes := []Index{}
+	for _, dir := range dirs {
+		indexName := dir.Name()
+		remote, err := gitutil.GetRemoteURL(filepath.Join(path, indexName))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list the remote URL for index %s", indexName)
+		}
+
+		indexes = append(indexes, Index{
+			Name: indexName,
+			URL:  remote,
+		})
+	}
+	return indexes, nil
+}

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexoperations
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/internal/gitutil"
+	"sigs.k8s.io/krew/internal/testutil"
+)
+
+func TestListIndexes(t *testing.T) {
+	tmpDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	wantIndexes := []Index{
+		{
+			Name: "custom",
+			URL:  "https://github.com/custom/index.git",
+		},
+		{
+			Name: "default",
+			URL:  "https://github.com/default/index.git",
+		},
+	}
+
+	for _, index := range wantIndexes {
+		path := tmpDir.Path("index/" + index.Name)
+		if err := os.MkdirAll(path, os.ModePerm); err != nil {
+			t.Fatalf("cannot create directory %q: %s", filepath.Dir(path), err)
+		}
+		_, err := gitutil.Exec(path, "init")
+		if err != nil {
+			t.Fatalf("error initializing git repo: %s", err)
+		}
+		_, err = gitutil.Exec(path, "remote", "add", "origin", index.URL)
+		if err != nil {
+			t.Fatalf("error setting remote origin: %s", err)
+		}
+	}
+
+	gotIndexes, err := ListIndexes(environment.NewPaths(tmpDir.Root()).IndexBase())
+	if err != nil {
+		t.Errorf("error listing indexes: %v", err)
+	}
+	if diff := cmp.Diff(wantIndexes, gotIndexes); diff != "" {
+		t.Errorf("output does not match: %s", diff)
+	}
+}


### PR DESCRIPTION
Initial implementation of `kubectl krew index list`. This prints the indexes in a table in the same format as `kubectl krew list`:
```
$ KREW_ROOT="/home/kimc/playground" X_KREW_ENABLE_MULTI_INDEX=1 ./bin/krew-linux_amd64 index list
INDEX    URL
default  https://github.com/kubernetes-sigs/krew-index.git
```

I slightly refactored the `exec` function in gitutil to return the output of the command. The existing uses of it don't need it but I'm using the output from `git config --get remote.origin.url` to get the index's remote url. Let me know if there's a better way to get the url from git, that was the only way I knew how.

Related issue: #483 
<!-- For proposed features, make sure there's an issue it's discussed first -->
