### PR TITLE
Closes #541: isSupportedAPIVersion's check is now relaxed

### DIFF
--- a/internal/index/validation/validate.go
+++ b/internal/index/validation/validate.go
@@ -55,7 +55,13 @@ func IsSafePluginName(name string) bool {
 }
 
 func isSupportedAPIVersion(apiVersion string) bool {
-	return apiVersion == constants.CurrentAPIVersion
+	versions := constants.GetSupportedAPIVersions()
+	for version := range versions {
+		if apiVersion == versions[version] {
+			return true
+		}
+	}
+	return false
 }
 
 func isValidSHA256(s string) bool { return validSHA256.MatchString(s) }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,3 +28,8 @@ const (
 	// the features around multiple indexes (this will be removed later on).
 	EnableMultiIndexSwitch = "X_KREW_ENABLE_MULTI_INDEX"
 )
+
+// GetSupportedAPIVersions returns a list containing all the supported versions of the API in from of strings.
+func GetSupportedAPIVersions() [1]string {
+	return [1]string{"krew.googlecontainertools.github.com/v1alpha2"}
+}


### PR DESCRIPTION


isSupportedAPIVersion function now checks to see if the input (apiVersion) exists within a list defined in pkg\constants\constants.go, if so it returns true, otherwise false is returned.

The function GetSupportedAPIVersions in constants.go is how the supported versions list is accessed. (It is hardcoded however, can be modified to use an external file instead)

Fixes #541
Related issue: #541
<!-- For proposed features, make sure there's an issue it's discussed first -->
