### PR TITLE
Add index add command

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
 	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/pkg/constants"
@@ -54,9 +55,27 @@ each configured index in table format.`,
 	},
 }
 
+var indexAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new index",
+	Long: `Configure a new index to install plugins from.
+
+Example:
+  kubectl krew index add index-name index-url`,
+	RunE: func(_ *cobra.Command, args []string) error {
+		err := indexoperations.AddIndex(paths.IndexBase(), args[0], args[1])
+		if err != nil {
+			return errors.Wrapf(err, "failed to add index %s: %s", args[0], args[1])
+		}
+		klog.Infoln("Successfully added index")
+		return nil
+	},
+}
+
 func init() {
 	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
 		indexCmd.AddCommand(indexListCmd)
+		indexCmd.AddCommand(indexAddCmd)
 		rootCmd.AddCommand(indexCmd)
 	}
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
 
 	"sigs.k8s.io/krew/internal/index/indexoperations"
 	"sigs.k8s.io/krew/pkg/constants"
@@ -46,11 +45,6 @@ each configured index in table format.`,
 		indexes, err := indexoperations.ListIndexes(paths.IndexBase())
 		if err != nil {
 			return errors.Wrap(err, "failed to list indexes")
-		}
-
-		if len(indexes) == 0 {
-			klog.Info(indexoperations.NoIndexMessage)
-			return nil
 		}
 
 		var rows [][]string

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -62,7 +62,11 @@ var indexAddCmd = &cobra.Command{
 
 Example:
   kubectl krew index add index-name index-url`,
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return cmd.Help()
+		}
+
 		err := indexoperations.AddIndex(paths.IndexBase(), args[0], args[1])
 		if err != nil {
 			return errors.Wrapf(err, "failed to add index %s: %s", args[0], args[1])

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -56,20 +56,15 @@ each configured index in table format.`,
 }
 
 var indexAddCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a new index",
-	Long: `Configure a new index to install plugins from.
-
-Example:
-  kubectl krew index add index-name index-url`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 2 {
-			return cmd.Help()
-		}
-
+	Use:     "add",
+	Short:   "Add a new index",
+	Long:    "Configure a new index to install plugins from.",
+	Example: "kubectl krew index add default " + constants.IndexURI,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(_ *cobra.Command, args []string) error {
 		err := indexoperations.AddIndex(paths.IndexBase(), args[0], args[1])
 		if err != nil {
-			return errors.Wrapf(err, "failed to add index %s: %s", args[0], args[1])
+			return errors.Wrap(err, "failed to add index")
 		}
 		klog.Infoln("Successfully added index")
 		return nil

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -47,6 +47,12 @@ each configured index in table format.`,
 		if err != nil {
 			return errors.Wrap(err, "failed to list indexes")
 		}
+
+		if len(indexes) == 0 {
+			klog.Info(indexoperations.NoIndexMessage)
+			return nil
+		}
+
 		var rows [][]string
 		for _, index := range indexes {
 			rows = append(rows, []string{index.Name, index.URL})
@@ -62,12 +68,7 @@ var indexAddCmd = &cobra.Command{
 	Example: "kubectl krew index add default " + constants.IndexURI,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(_ *cobra.Command, args []string) error {
-		err := indexoperations.AddIndex(paths.IndexBase(), args[0], args[1])
-		if err != nil {
-			return errors.Wrap(err, "failed to add index")
-		}
-		klog.Infoln("Successfully added index")
-		return nil
+		return indexoperations.AddIndex(paths.IndexBase(), args[0], args[1])
 	},
 }
 

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -117,6 +117,7 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	if err := ensureDirs(paths.BasePath(),
 		paths.InstallPath(),
 		paths.BinPath(),
+		paths.IndexBase(),
 		paths.InstallReceiptsPath()); err != nil {
 		klog.Fatal(err)
 	}

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtest
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/krew/pkg/constants"
+)
+
+func TestKrewIndex(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	initialList := test.WithMigratedIndex().WithEnv(constants.EnableMultiIndexSwitch, 1).Krew("index", "list").RunOrFailOutput()
+	if !bytes.Contains(initialList, []byte(constants.IndexURI)) {
+		t.Fatalf("expected krew-index in output:\n%s", string(initialList))
+	}
+
+	indexName := "foo"
+	test.Krew("index", "add", indexName, constants.IndexURI).RunOrFail()
+	if _, err := os.Stat(filepath.Join(test.Root(), "index", indexName, ".git")); err != nil {
+		t.Fatalf("error adding index: %s", err)
+	}
+
+	eventualList := test.Krew("index", "list").RunOrFailOutput()
+	if !bytes.Contains(eventualList, []byte(indexName)) {
+		t.Fatalf("expected index 'foo' in output:\n%s", string(eventualList))
+	}
+}

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -53,7 +53,7 @@ func TestKrewIndexList(t *testing.T) {
 	defer cleanup()
 
 	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
-	out := test.Krew("index", "list").RunOrFailOutput()
+	out := string(test.Krew("index", "list").RunOrFailOutput())
 	if !bytes.Contains(out, []byte(constants.DefaultIndexName)) {
 		t.Fatalf("expected index 'default' in output:\n%s", string(out))
 	}

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -15,7 +15,6 @@
 package integrationtest
 
 import (
-	"bytes"
 	"os"
 	"testing"
 
@@ -53,15 +52,17 @@ func TestKrewIndexList(t *testing.T) {
 	defer cleanup()
 
 	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
-	out := string(test.Krew("index", "list").RunOrFailOutput())
-	if !bytes.Contains(out, []byte(constants.DefaultIndexName)) {
-		t.Fatalf("expected index 'default' in output:\n%s", string(out))
+	out := test.Krew("index", "list").RunOrFailOutput()
+	if indexes := lines(out); len(indexes) < 2 {
+		// the first line is the header
+		t.Fatal("expected at least 1 index in output")
 	}
 
 	test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFail()
 	out = test.Krew("index", "list").RunOrFailOutput()
-	if !bytes.Contains(out, []byte("foo")) {
-		t.Fatalf("expected index 'foo' in output:\n%s", string(out))
+	if indexes := lines(out); len(indexes) < 3 {
+		// the first line is the header
+		t.Fatal("expected 2 indexes in output")
 	}
 }
 
@@ -78,7 +79,8 @@ func TestKrewIndexList_NoIndexes(t *testing.T) {
 	}
 
 	out := test.Krew("index", "list").RunOrFailOutput()
-	if !bytes.Equal(out, []byte("INDEX  URL\n")) {
+	if indexes := lines(out); len(indexes) > 1 {
+		// the first line is the header
 		t.Fatalf("expected index list to be empty:\n%s", string(out))
 	}
 }

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -286,6 +286,7 @@ func (it *ITest) initializeIndex() {
 		it.t.Fatalf("cannot restore index from cache: %s", err)
 	}
 
+	// TODO(chriskim06) simplify once multi-index is enabled
 	for _, e := range it.env {
 		if strings.Contains(e, constants.EnableMultiIndexSwitch) {
 			if err := indexmigration.Migrate(environment.NewPaths(it.Root())); err != nil {

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -288,7 +288,9 @@ func (it *ITest) initializeIndex() {
 
 	for _, e := range it.env {
 		if strings.Contains(e, constants.EnableMultiIndexSwitch) {
-			indexmigration.Migrate(environment.NewPaths(it.Root()))
+			if err := indexmigration.Migrate(environment.NewPaths(it.Root())); err != nil {
+				it.t.Fatalf("error migrating index: %s", err)
+			}
 		}
 	}
 }

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -173,13 +173,6 @@ func (it *ITest) WithIndex() *ITest {
 	return it
 }
 
-// WithMigratedIndex initializes the index and performs the index migration.
-func (it *ITest) WithMigratedIndex() *ITest {
-	it.initializeIndex()
-	it.migrateIndex()
-	return it
-}
-
 // WithEnv sets an environment variable for the krew run.
 func (it *ITest) WithEnv(key string, value interface{}) *ITest {
 	if key == "KREW_ROOT" {
@@ -292,12 +285,11 @@ func (it *ITest) initializeIndex() {
 	if err := cmd.Run(); err != nil {
 		it.t.Fatalf("cannot restore index from cache: %s", err)
 	}
-}
 
-func (it *ITest) migrateIndex() {
-	err := indexmigration.Migrate(environment.NewPaths(it.Root()))
-	if err != nil {
-		it.t.Fatalf("could not migrate index: %s", err)
+	for _, e := range it.env {
+		if strings.Contains(e, constants.EnableMultiIndexSwitch) {
+			indexmigration.Migrate(environment.NewPaths(it.Root()))
+		}
 	}
 }
 

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -56,6 +57,10 @@ func ListIndexes(path string) ([]Index, error) {
 
 // AddIndex initializes a new index to install plugins from.
 func AddIndex(path, name, url string) error {
+	if strings.ContainsAny(name, "./") {
+		return errors.New("index name cannot contain path characters")
+	}
+
 	dir := filepath.Join(path, name)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return gitutil.EnsureCloned(url, dir)

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -16,6 +16,7 @@ package indexoperations
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -51,4 +52,13 @@ func ListIndexes(path string) ([]Index, error) {
 		})
 	}
 	return indexes, nil
+}
+
+// AddIndex initializes a new index to download plugins from.
+func AddIndex(path, name, url string) error {
+	dir := filepath.Join(path, name)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		return errors.Wrapf(err, "index '%s' already exists", name)
+	}
+	return gitutil.EnsureCloned(url, dir)
 }

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -54,7 +54,7 @@ func ListIndexes(path string) ([]Index, error) {
 	return indexes, nil
 }
 
-// AddIndex initializes a new index to download plugins from.
+// AddIndex initializes a new index to install plugins from.
 func AddIndex(path, name, url string) error {
 	dir := filepath.Join(path, name)
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -23,13 +23,9 @@ import (
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/krew/internal/gitutil"
-	"sigs.k8s.io/krew/pkg/constants"
 )
 
-var (
-	NoIndexMessage   = "No index configured, run kubectl krew index add default " + constants.IndexURI + " to get started"
-	validNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
-)
+var validNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // Index describes the name and URL of a configured index.
 type Index struct {
@@ -41,9 +37,7 @@ type Index struct {
 // the base path of the index.
 func ListIndexes(path string) ([]Index, error) {
 	dirs, err := ioutil.ReadDir(path)
-	if os.IsNotExist(err) {
-		return nil, nil
-	} else if err != nil {
+	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read directory %s", path)
 	}
 

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -57,8 +57,10 @@ func ListIndexes(path string) ([]Index, error) {
 // AddIndex initializes a new index to install plugins from.
 func AddIndex(path, name, url string) error {
 	dir := filepath.Join(path, name)
-	if _, err := os.Stat(dir); !os.IsNotExist(err) {
-		return errors.Wrapf(err, "index '%s' already exists", name)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return gitutil.EnsureCloned(url, dir)
+	} else if err != nil {
+		return errors.Wrapf(err, "failed to describe %s", dir)
 	}
-	return gitutil.EnsureCloned(url, dir)
+	return errors.New("index already exists")
 }

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -60,7 +60,7 @@ func ListIndexes(path string) ([]Index, error) {
 // AddIndex initializes a new index to install plugins from.
 func AddIndex(path, name, url string) error {
 	if !IsValidIndexName(name) {
-		return errors.New("index name cannot contain path characters")
+		return errors.New("invalid index name")
 	}
 
 	dir := filepath.Join(path, name)

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -66,6 +66,9 @@ func TestAddIndexSuccess(t *testing.T) {
 	if err := AddIndex(tmpDir.Path("index"), indexName, localRepo); err != nil {
 		t.Errorf("error adding index: %v", err)
 	}
+	if _, err := os.Stat(tmpDir.Path("index/" + indexName)); err != nil {
+		t.Errorf("error reading newly added index: %s", err)
+	}
 }
 
 func TestAddIndexFailure(t *testing.T) {
@@ -84,6 +87,28 @@ func TestAddIndexFailure(t *testing.T) {
 
 	if err := AddIndex(indexRoot, indexName, localRepo); err == nil {
 		t.Error("expected error when adding an index that already exists")
+	}
+
+	if err := AddIndex(indexRoot, "foo/bar", ""); err == nil {
+		t.Error("expected error with invalid index name")
+	}
+}
+
+func TestIsValidIndexName(t *testing.T) {
+	if IsValidIndexName(" ") {
+		t.Error("name cannot contain spaces")
+	}
+	if IsValidIndexName("foo/bar") {
+		t.Error("name cannot contain forward slashes")
+	}
+	if IsValidIndexName("foo\\bar") {
+		t.Error("name cannot contain back slashes")
+	}
+	if IsValidIndexName("foo.bar") {
+		t.Error("name cannot contain forward periods")
+	}
+	if !IsValidIndexName("foo") {
+		t.Error("expected valid index name: foo")
 	}
 }
 

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -63,11 +63,22 @@ func TestAddIndexSuccess(t *testing.T) {
 	localRepo := tmpDir.Path("local/" + indexName)
 	initEmptyGitRepo(t, localRepo, "")
 
-	if err := AddIndex(tmpDir.Path("index"), indexName, localRepo); err != nil {
+	indexRoot := tmpDir.Path("index")
+	if err := AddIndex(indexRoot, indexName, localRepo); err != nil {
 		t.Errorf("error adding index: %v", err)
 	}
-	if _, err := os.Stat(tmpDir.Path("index/" + indexName)); err != nil {
-		t.Errorf("error reading newly added index: %s", err)
+	gotIndexes, err := ListIndexes(indexRoot)
+	if err != nil {
+		t.Errorf("error listing indexes: %s", err)
+	}
+	wantIndexes := []Index{
+		{
+			Name: indexName,
+			URL:  localRepo,
+		},
+	}
+	if diff := cmp.Diff(wantIndexes, gotIndexes); diff != "" {
+		t.Errorf("expected index %s in list: %s", indexName, diff)
 	}
 }
 

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -95,20 +95,43 @@ func TestAddIndexFailure(t *testing.T) {
 }
 
 func TestIsValidIndexName(t *testing.T) {
-	if IsValidIndexName(" ") {
-		t.Error("name cannot contain spaces")
+	tests := []struct {
+		name  string
+		index string
+		want  bool
+	}{
+		{
+			name:  "with space",
+			index: "foo bar",
+			want:  false,
+		},
+		{
+			name:  "with forward slash",
+			index: "foo/bar",
+			want:  false,
+		},
+		{
+			name:  "with back slash",
+			index: "foo\\bar",
+			want:  false,
+		},
+		{
+			name:  "with period",
+			index: "foo.bar",
+			want:  false,
+		},
+		{
+			name:  "valid name",
+			index: "foo",
+			want:  true,
+		},
 	}
-	if IsValidIndexName("foo/bar") {
-		t.Error("name cannot contain forward slashes")
-	}
-	if IsValidIndexName("foo\\bar") {
-		t.Error("name cannot contain back slashes")
-	}
-	if IsValidIndexName("foo.bar") {
-		t.Error("name cannot contain forward periods")
-	}
-	if !IsValidIndexName("foo") {
-		t.Error("expected valid index name: foo")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidIndexName(tt.index); tt.want != got {
+				t.Errorf("IsValidIndexName(%s), got = %t, want = %t", tt.index, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -65,20 +65,20 @@ func TestAddIndex(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid git repository",
+			name: "invalid git repository",
+			args: args{
+				index: Index{
+					Name: "foo",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "preexisting index",
 			args: args{
 				index: Index{
 					Name: "foo",
 					URL:  "https://github.com/valid/index.git",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid git repository",
-			args: args{
-				index: Index{
-					Name: "bar",
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION
Relatively small change. The majority of it is the test I added. I wasn't sure how to test the case where an index is added since it relies on git to clone the repo, so the only test cases I have are negative ones where the index with a name has already been configured and an invalid url is provided for the clone operation. I was thinking of using `constants.IndexURI` in a test case but didn't like that the unit test would need to be able to reach github so I didn't add it. 

Related issue: #483 
<!-- For proposed features, make sure there's an issue it's discussed first -->
