### PR TITLE
remove codecov.io integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@
 /SECURITY_CONTACTS
 /.travis.yml
 /code-of-conduct.md
-/coverage.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       run: hack/run-lint.sh
 
     - name: Run unit tests
-      run: go test -short -coverprofile=coverage.txt -covermode=atomic ./...
+      run: go test -short ./...
 
     - name: Make binaries && verify krew installation
       run: hack/make-all.sh

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@
 
 out/
 build/
-coverage.txt

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 # Krew
 
 [![Build Status](https://travis-ci.org/kubernetes-sigs/krew.svg?branch=master)](https://travis-ci.org/kubernetes-sigs/krew)
-[![Code Coverage](https://codecov.io/gh/kubernetes-sigs/krew/branch/master/graph/badge.svg)](https://codecov.io/gh/kubernetes-sigs/krew)
 [![Go Report Card](https://goreportcard.com/badge/kubernetes-sigs/krew)](https://goreportcard.com/report/kubernetes-sigs/krew)
 [![LICENSE](https://img.shields.io/github/license/kubernetes-sigs/krew.svg)](https://github.com/kubernetes-sigs/krew/blob/master/LICENSE)
 [![Releases](https://img.shields.io/github/release-pre/kubernetes-sigs/krew.svg)](https://github.com/kubernetes-sigs/krew/releases)


### PR DESCRIPTION
After switching fully to GitHub Workflows we no longer use Codecov.io. We
also didn't really get much out of it.

/assign @corneliusweig