### PR TITLE
site: fix slug for release-automation page

### DIFF
--- a/site/content/docs/developer-guide/release/release-automation.md
+++ b/site/content/docs/developer-guide/release/release-automation.md
@@ -1,6 +1,6 @@
 ---
 title: Automating plugin updates
-slug: updating-plugins
+slug: automating-updates
 weight: 300
 ---
 


### PR DESCRIPTION
Sadly `updating-plugins` was reused in two pages (this + `plugin-updates.md`).
I linked to this page from krew-index PRs several times.
But now we have to break that one in favor of this and have that link go to
the intended page in the first place.

/assign @corneliusweig