### PR TITLE
remove unused type installation.PluginEntry

### DIFF
--- a/internal/installation/install.go
+++ b/internal/installation/install.go
@@ -45,12 +45,6 @@ type installOperation struct {
 	binDir     string
 }
 
-// PluginEntry describes a plugin and the index it comes from.
-type PluginEntry struct {
-	Plugin    index.Plugin
-	IndexName string
-}
-
 // Plugin lifecycle errors
 var (
 	ErrIsAlreadyInstalled = errors.New("can't install, the newest version is already installed")


### PR DESCRIPTION
currently it appears that the pluginEntry type can just be in the
cmd/krew pkg. 

cc: @chriskim06
/assign @corneliusweig
/area multi-index