### PR TITLE
Use special "detached" index for manifest plugins

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/pathutil"
-	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
 
@@ -119,7 +118,7 @@ Remarks:
 				}
 				install = append(install, pluginEntry{
 					p:         plugin,
-					indexName: constants.DefaultIndexName,
+					indexName: "detached",
 				})
 			} else if *manifestURL != "" {
 				plugin, err := readPluginFromURL(*manifestURL)
@@ -128,7 +127,7 @@ Remarks:
 				}
 				install = append(install, pluginEntry{
 					p:         plugin,
-					indexName: constants.DefaultIndexName,
+					indexName: "detached",
 				})
 			}
 

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/krew/internal/installation/receipt"
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
@@ -133,7 +132,7 @@ func TestKrewInstall_Manifest(t *testing.T) {
 		"--manifest", filepath.Join("testdata", validPlugin+constants.ManifestExtension)).
 		RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
-	assertManifestPluginIndex(t, test, validPlugin)
+	test.AssertPluginFromIndex(t, "detached", validPlugin)
 }
 
 func TestKrewInstall_ManifestURL(t *testing.T) {
@@ -148,7 +147,7 @@ func TestKrewInstall_ManifestURL(t *testing.T) {
 		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
 		RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
-	assertManifestPluginIndex(t, test, validPlugin)
+	test.AssertPluginFromIndex(t, "detached", validPlugin)
 }
 
 func TestKrewInstall_ManifestAndArchive(t *testing.T) {
@@ -162,7 +161,7 @@ func TestKrewInstall_ManifestAndArchive(t *testing.T) {
 		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
 		RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + fooPlugin)
-	assertManifestPluginIndex(t, test, fooPlugin)
+	test.AssertPluginFromIndex(t, "detached", fooPlugin)
 }
 
 func TestKrewInstall_OnlyArchive(t *testing.T) {
@@ -219,15 +218,4 @@ func TestKrewInstall_NoManifestArgsWhenPositionalArgsSpecified(t *testing.T) {
 func localTestServer() (string, func()) {
 	s := httptest.NewServer(http.FileServer(http.Dir("testdata")))
 	return s.URL, s.Close
-}
-
-func assertManifestPluginIndex(t *testing.T, test *ITest, plugin string) {
-	receiptPath := test.TempDir().Path("receipts/" + plugin + constants.ManifestExtension)
-	r, err := receipt.Load(receiptPath)
-	if err != nil {
-		t.Fatalf("error loading receipt: %v", err)
-	}
-	if r.Status.Source.Name != "detached" {
-		t.Errorf("wanted index 'detached', got: '%s'", r.Status.Source.Name)
-	}
 }

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/indexmigration"
+	"sigs.k8s.io/krew/internal/installation/receipt"
 	"sigs.k8s.io/krew/internal/testutil"
 	"sigs.k8s.io/krew/pkg/constants"
 )
@@ -152,6 +153,19 @@ func (it *ITest) AssertExecutableNotInPATH(file string) {
 	it.t.Helper()
 	if _, err := it.LookupExecutable(file); err == nil {
 		it.t.Fatalf("executable %s still exists in PATH", file)
+	}
+}
+
+// AssertPluginFromIndex asserts that a receipt exists for the given plugin and
+// that it is from the specified index.
+func (it *ITest) AssertPluginFromIndex(t *testing.T, indexName, plugin string) {
+	receiptPath := environment.NewPaths(it.Root()).PluginInstallReceiptPath(plugin)
+	r, err := receipt.Load(receiptPath)
+	if err != nil {
+		t.Fatalf("error loading receipt: %v", err)
+	}
+	if r.Status.Source.Name != indexName {
+		t.Errorf("wanted index '%s', got: '%s'", indexName, r.Status.Source.Name)
 	}
 }
 


### PR DESCRIPTION
Let me know if you want me to move this out to a package level variable, figured it would be ok like this since this situation is only encountered in this file.

Related issue: #483
<!-- For proposed features, make sure there's an issue it's discussed first -->
