### PR TITLE
integration_test: Use new helper method

### DIFF
--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -44,6 +44,7 @@ func TestKrewInstall(t *testing.T) {
 
 	test.Krew("install", validPlugin).RunOrFailOutput()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+	test.AssertPluginFromIndex(validPlugin, "default")
 }
 
 func TestKrewInstallReRun(t *testing.T) {
@@ -103,6 +104,7 @@ func TestKrewInstall_ExplicitDefaultIndex(t *testing.T) {
 
 	test.Krew("install", "default/"+validPlugin).RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+	test.AssertPluginFromIndex(validPlugin, "default")
 }
 
 func TestKrewInstall_CustomIndex(t *testing.T) {
@@ -115,6 +117,7 @@ func TestKrewInstall_CustomIndex(t *testing.T) {
 	test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFail()
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
+	test.AssertPluginFromIndex(validPlugin, "foo")
 
 	if err := test.Krew("install", "invalid/"+validPlugin2).Run(); err == nil {
 		t.Fatal("expected install from invalid index to fail")
@@ -132,7 +135,7 @@ func TestKrewInstall_Manifest(t *testing.T) {
 		"--manifest", filepath.Join("testdata", validPlugin+constants.ManifestExtension)).
 		RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
-	test.AssertPluginFromIndex(t, "detached", validPlugin)
+	test.AssertPluginFromIndex(validPlugin, "detached")
 }
 
 func TestKrewInstall_ManifestURL(t *testing.T) {
@@ -147,7 +150,7 @@ func TestKrewInstall_ManifestURL(t *testing.T) {
 		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
 		RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
-	test.AssertPluginFromIndex(t, "detached", validPlugin)
+	test.AssertPluginFromIndex(validPlugin, "detached")
 }
 
 func TestKrewInstall_ManifestAndArchive(t *testing.T) {
@@ -161,7 +164,7 @@ func TestKrewInstall_ManifestAndArchive(t *testing.T) {
 		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
 		RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + fooPlugin)
-	test.AssertPluginFromIndex(t, "detached", fooPlugin)
+	test.AssertPluginFromIndex(fooPlugin, "detached")
 }
 
 func TestKrewInstall_OnlyArchive(t *testing.T) {

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -158,14 +158,16 @@ func (it *ITest) AssertExecutableNotInPATH(file string) {
 
 // AssertPluginFromIndex asserts that a receipt exists for the given plugin and
 // that it is from the specified index.
-func (it *ITest) AssertPluginFromIndex(t *testing.T, indexName, plugin string) {
+func (it *ITest) AssertPluginFromIndex(plugin, indexName string) {
+	it.t.Helper()
+
 	receiptPath := environment.NewPaths(it.Root()).PluginInstallReceiptPath(plugin)
 	r, err := receipt.Load(receiptPath)
 	if err != nil {
-		t.Fatalf("error loading receipt: %v", err)
+		it.t.Fatalf("error loading receipt: %v", err)
 	}
 	if r.Status.Source.Name != indexName {
-		t.Errorf("wanted index '%s', got: '%s'", indexName, r.Status.Source.Name)
+		it.t.Errorf("wanted index '%s', got: '%s'", indexName, r.Status.Source.Name)
 	}
 }
 


### PR DESCRIPTION
* refactor AssertPluginFromIndex
  * no need to pass t
  * mark as helper
  * swap parameter order to match method name + more intuitive

* refactor existing "krew install" integ tests to use this


Related: #568
/assign @chriskim06
/area multi-index