### PR TITLE
cmd: make krew search work with multiple indexes

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -62,7 +62,7 @@ Examples:
 
 		var plugins []pluginEntry
 		for _, idx := range indexes {
-			ps, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(constants.DefaultIndexName))
+			ps, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(idx.Name))
 			if err != nil {
 				return errors.Wrap(err, "failed to load the list of plugins from the index")
 			}


### PR DESCRIPTION
Mostly just refactoring. Added test to make sure search output is
alphabetically sorted (even in case of multiple indexes).

Related issue: #566, #483
/assign @chriskim06 
/assign @corneliusweig 
/area multi-index