### PR TITLE
Fix mispelling of hack folder

### DIFF
--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -37,7 +37,7 @@ goimports -local sigs.k8s.io/krew -w cmd pkg integration_test
 Shell scripts are automatically formatted by `shfmt`, to install and to validate run:
 
 ```bash
-hach/run-lint.sh
+hack/run-lint.sh
 ```
 
 If format is in expected format, there will be no output.


### PR DESCRIPTION
Fix a little mispelling in the docs regarding the `hack` folder
