### PR TITLE
Document that gnu utils  are required in mac

### DIFF
--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -17,16 +17,12 @@ git clone https://github.com/kubernetes-sigs/krew .
 git remote set-url origin --push no_push   # to avoid pushes
 ```
 
-### Mac specific requirements
+### Using macOS for development
 
-The tools provided in the `hack` folder expect you to use GNU binaries.
-
-The easiest way to install them is to use brew
+The tools provided in the `hack` folder expect you to use GNU binaries, the easiest way to install them is to use brew
 
 ```bash
-brew install coreutils
-brew install grep
-brew intall gnu-sed
+brew install coreutils grep gnu-sed
 ```
 And remember to add them to your `$PATH` to make them your default binaries
 

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -17,6 +17,25 @@ git clone https://github.com/kubernetes-sigs/krew .
 git remote set-url origin --push no_push   # to avoid pushes
 ```
 
+### Mac specific requirements
+
+The tools provided in the `hack` folder expect you to use GNU binaries.
+
+The easiest way to install them is to use brew
+
+```bash
+brew install coreutils
+brew install grep
+brew intall gnu-sed
+```
+And remember to add them to your `$PATH` to make them your default binaries
+
+```bash
+export PATH=$(brew --prefix coreutils)/libexec/gnubin:$PATH
+export PATH="$(brew --prefix grep)/libexec/gnubin:$PATH"
+export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH"
+```
+
 ## Code style
 
 Krew adheres to standard `golang` code formatting conventions, and also expects


### PR DESCRIPTION
Document that GNU binaries are required for the support scripts.

grep and sed are not part of the coreutils package so we need to install them as another package.