### PR TITLE
integration_test: Refine cmd run utilities

### DIFF
--- a/integration_test/commandline_test.go
+++ b/integration_test/commandline_test.go
@@ -22,7 +22,7 @@ func TestUnknownCommand(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	if err := test.Krew("foobar").Run(); err == nil {
+	if _, err := test.Krew("foobar").Run(); err == nil {
 		t.Errorf("Expected `krew foobar` to fail")
 	}
 }

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -28,19 +28,19 @@ func TestKrewIndexAdd(t *testing.T) {
 	defer cleanup()
 
 	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
-	if err := test.Krew("index", "add").Run(); err == nil {
+	if _, err := test.Krew("index", "add").Run(); err == nil {
 		t.Fatal("expected index add with no args to fail")
 	}
-	if err := test.Krew("index", "add", "foo", "https://invalid").Run(); err == nil {
+	if _, err := test.Krew("index", "add", "foo", "https://invalid").Run(); err == nil {
 		t.Fatal("expected index add with invalid URL to fail")
 	}
 	if err := test.Krew("index", "add", "../../usr/bin", constants.IndexURI); err == nil {
 		t.Fatal("expected index add with path characters to fail")
 	}
-	if err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err != nil {
+	if _, err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err != nil {
 		t.Fatalf("error adding new index: %v", err)
 	}
-	if err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err == nil {
+	if _, err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err == nil {
 		t.Fatal("expected adding same index to fail")
 	}
 }
@@ -92,7 +92,7 @@ func TestKrewIndexRemove_nonExisting(t *testing.T) {
 	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
-	err := test.Krew("index", "remove", "non-existing").Run()
+	_, err := test.Krew("index", "remove", "non-existing").Run()
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -116,7 +116,7 @@ func TestKrewIndexRemoveFailsWhenPluginsInstalled(t *testing.T) {
 	defer cleanup()
 
 	test.Krew("install", validPlugin).RunOrFailOutput()
-	if err := test.Krew("index", "remove", "default").Run(); err == nil {
+	if _, err := test.Krew("index", "remove", "default").Run(); err == nil {
 		t.Fatal("expected error while removing index when there are installed plugins")
 	}
 

--- a/integration_test/info_test.go
+++ b/integration_test/info_test.go
@@ -41,7 +41,7 @@ func TestKrewInfoInvalidPlugin(t *testing.T) {
 	defer cleanup()
 
 	plugin := "invalid-plugin"
-	err := test.WithIndex().Krew("info", plugin).Run()
+	_, err := test.WithIndex().Krew("info", plugin).Run()
 	if err == nil {
 		t.Errorf("Expected `krew info %s` to fail", plugin)
 	}

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -119,7 +119,7 @@ func TestKrewInstall_CustomIndex(t *testing.T) {
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
 	test.AssertPluginFromIndex(validPlugin, "foo")
 
-	if err := test.Krew("install", "invalid/"+validPlugin2).Run(); err == nil {
+	if _, err := test.Krew("install", "invalid/"+validPlugin2).Run(); err == nil {
 		t.Fatal("expected install from invalid index to fail")
 	}
 	test.AssertExecutableNotInPATH("kubectl-" + validPlugin2)
@@ -173,7 +173,7 @@ func TestKrewInstall_OnlyArchive(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	err := test.Krew("install",
+	_, err := test.Krew("install",
 		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
 		Run()
 	if err == nil {
@@ -189,7 +189,7 @@ func TestKrewInstall_ManifestArgsAreMutuallyExclusive(t *testing.T) {
 	srv, shutdown := localTestServer()
 	defer shutdown()
 
-	if err := test.Krew("install",
+	if _, err := test.Krew("install",
 		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),
 		"--manifest-url", srv+"/"+validPlugin+constants.ManifestExtension).
 		Run(); err == nil {
@@ -203,7 +203,7 @@ func TestKrewInstall_NoManifestArgsWhenPositionalArgsSpecified(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	err := test.Krew("install", validPlugin,
+	_, err := test.Krew("install", validPlugin,
 		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),
 		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
 		Run()
@@ -211,7 +211,7 @@ func TestKrewInstall_NoManifestArgsWhenPositionalArgsSpecified(t *testing.T) {
 		t.Fatal("expected failure when positional args and --manifest specified")
 	}
 
-	err = test.Krew("install", validPlugin,
+	_, err = test.Krew("install", validPlugin,
 		"--manifest-url", filepath.Join("testdata", fooPlugin+constants.ManifestExtension)).Run()
 	if err == nil {
 		t.Fatal("expected failure when positional args and --manifest-url specified")

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -221,12 +221,10 @@ func (it *ITest) Run() ([]byte, error) {
 	cmd.Stderr = &b
 
 	start := time.Now()
-	if err := cmd.Run(); err != nil {
-		out := b.Bytes()
-		return out, errors.Wrapf(err, "krew %v: %v, %s", it.args, err, string(out))
-	}
+	err := cmd.Run()
+	out := b.Bytes()
 	it.t.Log("Ran in", time.Since(start))
-	return b.Bytes(), nil
+	return out, errors.Wrapf(err, "krew %v: %v, %s", it.args, err, string(out))
 }
 
 // RunOrFail runs the krew command and fails the test if the command returns an error.

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -31,17 +31,17 @@ func TestKrewUninstall(t *testing.T) {
 
 	test = test.WithIndex()
 
-	if err := test.Krew("uninstall").Run(); err == nil {
+	if _, err := test.Krew("uninstall").Run(); err == nil {
 		t.Fatal("expected failure without no arguments")
 	}
-	if err := test.Krew("uninstall", validPlugin).Run(); err == nil {
+	if _, err := test.Krew("uninstall", validPlugin).Run(); err == nil {
 		t.Fatal("expected failure deleting non-installed plugin")
 	}
 	test.Krew("install", validPlugin).RunOrFailOutput()
 	test.Krew("uninstall", validPlugin).RunOrFailOutput()
 	test.AssertExecutableNotInPATH("kubectl-" + validPlugin)
 
-	if err := test.Krew("uninstall", validPlugin).Run(); err == nil {
+	if _, err := test.Krew("uninstall", validPlugin).Run(); err == nil {
 		t.Fatal("expected failure for uninstalled plugin")
 	}
 }

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -44,7 +44,7 @@ func TestKrewUpdate(t *testing.T) {
 		t.Errorf("Less than %d plugins found, `krew update` most likely failed unless TestKrewSearchAll also failed", len(plugins)-1)
 	}
 
-	if err := test.Krew("update").Run(); err != nil {
+	if _, err := test.Krew("update").Run(); err != nil {
 		t.Fatal("re-run of 'update' must succeed")
 	}
 }

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -69,7 +69,7 @@ func TestKrewUpgradeWhenPlatformNoLongerMatches(t *testing.T) {
 	}
 
 	// if upgrading a specific plugin, it must fail, because no longer matching to a platform
-	err := test.Krew("upgrade", validPlugin, "--no-update-index").Run()
+	_, err := test.Krew("upgrade", validPlugin, "--no-update-index").Run()
 	if err == nil {
 		t.Fatal("expected failure when upgraded a specific plugin that no longer has a matching platform")
 	}
@@ -97,7 +97,7 @@ func TestKrewUpgrade_ValidPluginInstalledFromManifest(t *testing.T) {
 	}
 
 	// if upgrading a specific plugin, it must fail, because it's not included into index
-	err := test.Krew("upgrade", validPlugin, "--no-update-index").Run()
+	_, err := test.Krew("upgrade", validPlugin, "--no-update-index").Run()
 	if err == nil {
 		t.Fatal("expected failure when upgraded a specific plugin that is not included in index")
 	}


### PR DESCRIPTION
- refactored ITest.Run() to return ([]byte,error)
- refactored all Run*** methods to use ITest.Run()

This also will help us test commands that are expected to fail but were
previously not making their stdout/stderr available to the test case for
string tests.

Fixes #561
/assign @corneliusweig