### PR TITLE
Check index or plugin name safety in cmd

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	forceIndexDelete *bool
+	forceIndexDelete    *bool
+	errInvalidIndexName = errors.New("invalid index name")
 )
 
 // indexCmd represents the index command
@@ -70,7 +71,11 @@ var indexAddCmd = &cobra.Command{
 	Example: "kubectl krew index add default " + constants.IndexURI,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(_ *cobra.Command, args []string) error {
-		return indexoperations.AddIndex(paths, args[0], args[1])
+		name := args[0]
+		if !indexoperations.IsValidIndexName(name) {
+			return errInvalidIndexName
+		}
+		return indexoperations.AddIndex(paths, name, args[1])
 	},
 }
 
@@ -89,6 +94,9 @@ option is used ( not recommended).`,
 
 func indexDelete(_ *cobra.Command, args []string) error {
 	name := args[0]
+	if !indexoperations.IsValidIndexName(name) {
+		return errInvalidIndexName
+	}
 
 	ps, err := installation.InstalledPluginsFromIndex(paths.InstallReceiptsPath(), name)
 	if err != nil {

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -98,11 +98,11 @@ Remarks:
 
 			var install []pluginEntry
 			for _, name := range pluginNames {
-				if !validation.IsSafePluginName(name) {
-					return unsafePluginNameErr(name)
+				indexName, pluginName := pathutil.CanonicalPluginName(name)
+				if !validation.IsSafePluginName(pluginName) {
+					return unsafePluginNameErr(pluginName)
 				}
 
-				indexName, pluginName := pathutil.CanonicalPluginName(name)
 				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(indexName), pluginName)
 				if err != nil {
 					if os.IsNotExist(err) {

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/krew/cmd/krew/cmd/internal"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
+	"sigs.k8s.io/krew/internal/index/validation"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/pathutil"
 	"sigs.k8s.io/krew/pkg/index"
@@ -97,6 +98,10 @@ Remarks:
 
 			var install []pluginEntry
 			for _, name := range pluginNames {
+				if !validation.IsSafePluginName(name) {
+					return unsafePluginNameErr(name)
+				}
+
 				indexName, pluginName := pathutil.CanonicalPluginName(name)
 				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(indexName), pluginName)
 				if err != nil {

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	"sigs.k8s.io/krew/internal/index/validation"
 	"sigs.k8s.io/krew/internal/installation"
 )
 
@@ -38,6 +39,9 @@ Remarks:
   Failure to uninstall a plugin will result in an error and exit immediately.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, name := range args {
+			if !validation.IsSafePluginName(name) {
+				return unsafePluginNameErr(name)
+			}
 			klog.V(4).Infof("Going to uninstall plugin %s\n", name)
 			if err := installation.Uninstall(paths, name); err != nil {
 				return errors.Wrapf(err, "failed to uninstall plugin %s", name)
@@ -50,6 +54,8 @@ Remarks:
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"remove"},
 }
+
+func unsafePluginNameErr(n string) error { return fmt.Errorf("plugin name %q not allowed", n) }
 
 func init() {
 	rootCmd.AddCommand(uninstallCmd)

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -55,7 +55,7 @@ Remarks:
 	Aliases: []string{"remove"},
 }
 
-func unsafePluginNameErr(n string) error { return fmt.Errorf("plugin name %q not allowed", n) }
+func unsafePluginNameErr(n string) error { return errors.Errorf("plugin name %q not allowed", n) }
 
 func init() {
 	rootCmd.AddCommand(uninstallCmd)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -24,6 +24,7 @@ import (
 
 	"sigs.k8s.io/krew/cmd/krew/cmd/internal"
 	"sigs.k8s.io/krew/internal/index/indexscanner"
+	"sigs.k8s.io/krew/internal/index/validation"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/pathutil"
 )
@@ -64,6 +65,9 @@ kubectl krew upgrade foo bar"`,
 			var nErrors int
 			for _, name := range pluginNames {
 				indexName, pluginName := pathutil.CanonicalPluginName(name)
+				if !validation.IsSafePluginName(pluginName) {
+					return unsafePluginNameErr(pluginName)
+				}
 				plugin, err := indexscanner.LoadPluginByName(paths.IndexPluginsPath(indexName), pluginName)
 				if err != nil {
 					if !os.IsNotExist(err) {

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -138,7 +138,7 @@ func TestKrewIndexRemove_unsafe(t *testing.T) {
 	expected := "invalid index name"
 	cases := []string{"a/b", `a\b`, "../a", `..\a`}
 	for _, c := range cases {
-		b, err := test.Krew("index", "add", c, constants.IndexURI).Run()
+		b, err := test.Krew("index", "remove", c, constants.IndexURI).Run()
 		if err == nil {
 			t.Fatalf("%q: expected error", c)
 		} else if !strings.Contains(string(b), expected) {

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -138,7 +138,7 @@ func TestKrewIndexRemove_unsafe(t *testing.T) {
 	expected := "invalid index name"
 	cases := []string{"a/b", `a\b`, "../a", `..\a`}
 	for _, c := range cases {
-		b, err := test.Krew("index", "remove", c, constants.IndexURI).Run()
+		b, err := test.Krew("index", "remove", c).Run()
 		if err == nil {
 			t.Fatalf("%q: expected error", c)
 		} else if !strings.Contains(string(b), expected) {

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -58,6 +58,31 @@ func TestKrewInstallReRun(t *testing.T) {
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
 }
 
+func TestKrewInstallUnsafe(t *testing.T) {
+	skipShort(t)
+	test, cleanup := NewTest(t)
+	defer cleanup()
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
+
+	cases := []string{
+		`../index/` + validPlugin,
+		`..\index\` + validPlugin,
+		`../default/` + validPlugin,
+		`..\default\` + validPlugin,
+		`index-name/sub-directory/plugin-name`,
+	}
+
+	expectedErr := `not allowed`
+	for _, c := range cases {
+		b, err := test.Krew("install", c).Run()
+		if err == nil {
+			t.Fatalf("%q expected failure", c)
+		} else if !strings.Contains(string(b), expectedErr) {
+			t.Fatalf("%q does not contain err %q: %q", c, expectedErr, string(b))
+		}
+	}
+}
+
 func TestKrewInstall_MultiplePositionalArgs(t *testing.T) {
 	skipShort(t)
 

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -50,6 +50,31 @@ func TestKrewUpgrade(t *testing.T) {
 	}
 }
 
+func TestKrewUpgradeUnsafe(t *testing.T) {
+	skipShort(t)
+	test, cleanup := NewTest(t)
+	defer cleanup()
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
+
+	cases := []string{
+		`../index/` + validPlugin,
+		`..\index\` + validPlugin,
+		`../default/` + validPlugin,
+		`..\default\` + validPlugin,
+		`index-name/sub-directory/plugin-name`,
+	}
+
+	expectedErr := `not allowed`
+	for _, c := range cases {
+		b, err := test.Krew("upgrade", c).Run()
+		if err == nil {
+			t.Fatalf("%q expected failure", c)
+		} else if !strings.Contains(string(b), expectedErr) {
+			t.Fatalf("%q does not contain err %q: %q", c, expectedErr, string(b))
+		}
+	}
+}
+
 func TestKrewUpgradeWhenPlatformNoLongerMatches(t *testing.T) {
 	skipShort(t)
 

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -59,10 +59,6 @@ func ListIndexes(paths environment.Paths) ([]Index, error) {
 
 // AddIndex initializes a new index to install plugins from.
 func AddIndex(paths environment.Paths, name, url string) error {
-	if !IsValidIndexName(name) {
-		return errors.New("invalid index name")
-	}
-
 	dir := paths.IndexPath(name)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return gitutil.EnsureCloned(url, dir)
@@ -74,14 +70,11 @@ func AddIndex(paths environment.Paths, name, url string) error {
 
 // DeleteIndex removes specified index name. If index does not exist, returns an error that can be tested by os.IsNotExist.
 func DeleteIndex(paths environment.Paths, name string) error {
-	if !IsValidIndexName(name) {
-		return errors.New("invalid index name")
-	}
-
 	dir := paths.IndexPath(name)
 	if _, err := os.Stat(dir); err != nil {
 		return err
 	}
+
 	return os.RemoveAll(dir)
 }
 

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -182,6 +182,11 @@ func TestIsValidIndexName(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "relative path",
+			index: "../foo",
+			want:  false,
+		},
+		{
 			name:  "with back slash",
 			index: "foo\\bar",
 			want:  false,

--- a/internal/index/indexscanner/scanner.go
+++ b/internal/index/indexscanner/scanner.go
@@ -75,10 +75,6 @@ func LoadPluginListFromFS(indexDir string) ([]index.Plugin, error) {
 // LoadPluginByName loads a plugins index file by its name. When plugin
 // file not found, it returns an error that can be checked with os.IsNotExist.
 func LoadPluginByName(pluginsDir, pluginName string) (index.Plugin, error) {
-	if !validation.IsSafePluginName(pluginName) {
-		return index.Plugin{}, errors.Errorf("plugin name %q not allowed", pluginName)
-	}
-
 	klog.V(4).Infof("Reading plugin %q from %s", pluginName, pluginsDir)
 	return ReadPluginFromFile(filepath.Join(pluginsDir, pluginName+constants.ManifestExtension))
 }


### PR DESCRIPTION
tl;dr: Some krew cmds are currently susceptible to path manipulation through positional arguments. Low-level machinery isn't responsible for this, so move them to cmd + add tests.

Moving plugin name or index name safety checks to cmd/ where they are given by
the user to the program. This way we shift the need for validation from being
unit tests of low-level machinery to the integration_test which tests
user-facing concerns.

> Note: Checks will fail until #582 is merged and this patch is rebased on it.

Fixes #581
/assign @corneliusweig
/assign @chriskim06