### PR TITLE
constants: change the variable name

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -67,7 +67,7 @@ var indexAddCmd = &cobra.Command{
 	Use:     "add",
 	Short:   "Add a new index",
 	Long:    "Configure a new index to install plugins from.",
-	Example: "kubectl krew index add default " + constants.IndexURI,
+	Example: "kubectl krew index add default " + constants.DefaultIndexURI,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(_ *cobra.Command, args []string) error {
 		return indexoperations.AddIndex(paths, args[0], args[1])

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -106,7 +106,7 @@ func ensureIndexUpdated(_ *cobra.Command, _ []string) error {
 	preUpdateIndex, _ := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(constants.DefaultIndexName))
 
 	klog.V(1).Infof("Updating the local copy of plugin index (%s)", paths.IndexPath(constants.DefaultIndexName))
-	if err := gitutil.EnsureUpdated(constants.IndexURI, paths.IndexPath(constants.DefaultIndexName)); err != nil {
+	if err := gitutil.EnsureUpdated(constants.DefaultIndexURI, paths.IndexPath(constants.DefaultIndexName)); err != nil {
 		return errors.Wrap(err, "failed to update the local index")
 	}
 	fmt.Fprintln(os.Stderr, "Updated the local copy of plugin index.")

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -33,7 +33,7 @@ var versionCmd = &cobra.Command{
 Remarks:
   - GitTag describes the release name krew is built from.
   - GitCommit describes the git revision ID which krew is built from.
-  - IndexURI is the URI where the index is updated from.
+  - DefaultIndexURI is the URI where the index is updated from.
   - BasePath is the root directory for krew installation.
   - IndexPath is the directory that stores the local copy of the index git repository.
   - InstallPath is the directory for plugin installations.
@@ -42,7 +42,7 @@ Remarks:
 		conf := [][]string{
 			{"GitTag", version.GitTag()},
 			{"GitCommit", version.GitCommit()},
-			{"IndexURI", constants.IndexURI},
+			{"IndexURI", constants.DefaultIndexURI},
 			{"BasePath", paths.BasePath()},
 			{"IndexPath", paths.IndexPath(constants.DefaultIndexName)},
 			{"InstallPath", paths.InstallPath()},

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -34,7 +34,7 @@ func TestKrewIndexAdd(t *testing.T) {
 	if err := test.Krew("index", "add", "foo", "https://invalid").Run(); err == nil {
 		t.Fatal("expected index add with invalid URL to fail")
 	}
-	if err := test.Krew("index", "add", "../../usr/bin", constants.IndexURI); err == nil {
+	if err := test.Krew("index", "add", "../../usr/bin", constants.DefaultIndexURI); err == nil {
 		t.Fatal("expected index add with path characters to fail")
 	}
 	if err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err != nil {

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -318,7 +318,7 @@ func initFromGitClone(t *testing.T) ([]byte, error) {
 	defer cleanup()
 	indexRoot := indexDir.Root()
 
-	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", "--no-tags", constants.IndexURI)
+	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", "--no-tags", constants.DefaultIndexURI)
 	cmd.Dir = indexRoot
 	if err := cmd.Run(); err != nil {
 		return nil, err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,8 +20,8 @@ const (
 	ManifestExtension = ".yaml"
 	KrewPluginName    = "krew" // plugin name of krew itself
 
-	// IndexURI points to the upstream index.
-	IndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
+	// DefaultIndexURI points to the upstream index.
+	DefaultIndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
 	// DefaultIndexName is a magic string that's used for a plugin name specified without an index.
 	DefaultIndexName = "default"
 	// EnableMultiIndexSwitch is the name of the environment variable that needs to be set to use


### PR DESCRIPTION
This change indicates the possibility of non-centralized plugin index. However,
this breaks the API (e.g. exported pkg/constants), so I'm not sure we should do
this.

/assign @corneliusweig