### PR TITLE
fix const references

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -47,7 +47,7 @@ Examples:
 		indexes := []indexoperations.Index{
 			{
 				Name: constants.DefaultIndexName,
-				URL:  constants.IndexURI, // unused here but providing for completeness
+				URL:  constants.DefaultIndexURI, // unused here but providing for completeness
 			},
 		}
 		if os.Getenv(constants.EnableMultiIndexSwitch) != "" {

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -56,7 +56,7 @@ func TestKrewIndexAddUnsafe(t *testing.T) {
 	expected := "invalid index name"
 
 	for _, c := range cases {
-		b, err := test.Krew("index", "add", c, constants.IndexURI).Run()
+		b, err := test.Krew("index", "add", c, constants.DefaultIndexURI).Run()
 		if err == nil {
 			t.Fatalf("%q: expected error", c)
 		} else if !strings.Contains(string(b), expected) {


### PR DESCRIPTION
For some reason when we refactored the const name constants.IndexURI
https://github.com/kubernetes-sigs/krew/pull/584 its test run has inexplicably
succeeded https://github.com/kubernetes-sigs/krew/runs/559491631 despite some
references in main code + tests not updated.

(I appreciate if someone can take a look why that has happened.)

/priority P0
/assign @corneliusweig