### PR TITLE
cmd: modify upgrade to work with multiple indexes

### DIFF
--- a/cmd/krew/cmd/namingutils.go
+++ b/cmd/krew/cmd/namingutils.go
@@ -15,9 +15,13 @@
 package cmd
 
 import (
+	"regexp"
+
 	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
+
+var canonicalNameRegex = regexp.MustCompile(`^[\w-]+/[\w-]+$`)
 
 // indexOf returns the index name of a receipt.
 func indexOf(r index.Receipt) string {
@@ -47,4 +51,8 @@ func canonicalName(p index.Plugin, indexName string) string {
 		indexName = constants.DefaultIndexName
 	}
 	return indexName + "/" + p.Name
+}
+
+func isCanonicalName(s string) bool {
+	return canonicalNameRegex.MatchString(s)
 }

--- a/cmd/krew/cmd/namingutils_test.go
+++ b/cmd/krew/cmd/namingutils_test.go
@@ -114,13 +114,28 @@ func Test_canonicalName(t *testing.T) {
 }
 
 func Test_isCanonicalName(t *testing.T) {
-	if isCanonicalName("foo") {
-		t.Error("expected foo to not be considered a canonical name")
+	tests := []struct {
+		arg      string
+		expected bool
+	}{
+		{"foo", false},
+		{"../index/foo", false},
+		{"index/foo", true},
+		{"", false},
+		{"0-0", false},
+		{"a/", false},
+		{"/b", false},
+		{"a-a/b-b", true},
+		{"a//b", false},
+		{"a / b", false},
+		{"a /b", false},
+		{"a/ b", false},
 	}
-	if isCanonicalName("../index/foo") {
-		t.Error("expected ../index/foo to not be considered a canonical name")
-	}
-	if !isCanonicalName("index/foo") {
-		t.Error("expected index/foo to be considered a canonical name")
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			if isCanonicalName(tt.arg) != tt.expected {
+				t.Errorf("expected isCanonicalName(%q) to be %t", tt.arg, tt.expected)
+			}
+		})
 	}
 }

--- a/cmd/krew/cmd/namingutils_test.go
+++ b/cmd/krew/cmd/namingutils_test.go
@@ -112,3 +112,15 @@ func Test_canonicalName(t *testing.T) {
 		t.Errorf("expected=%q; got=%q", expected, got)
 	}
 }
+
+func Test_isCanonicalName(t *testing.T) {
+	if isCanonicalName("foo") {
+		t.Error("expected foo to not be considered a canonical name")
+	}
+	if isCanonicalName("../index/foo") {
+		t.Error("expected ../index/foo to not be considered a canonical name")
+	}
+	if !isCanonicalName("index/foo") {
+		t.Error("expected index/foo to be considered a canonical name")
+	}
+}

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -41,8 +41,7 @@ Remarks:
 		for _, name := range args {
 			if isCanonicalName(name) {
 				return errors.New("uninstall command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
-			}
-			if !validation.IsSafePluginName(name) {
+			} else if !validation.IsSafePluginName(name) {
 				return unsafePluginNameErr(name)
 			}
 			klog.V(4).Infof("Going to uninstall plugin %s\n", name)

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -39,10 +39,10 @@ Remarks:
   Failure to uninstall a plugin will result in an error and exit immediately.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, name := range args {
+			if isCanonicalName(name) {
+				return errors.New("uninstall command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
+			}
 			if !validation.IsSafePluginName(name) {
-				if isCanonicalName(name) {
-					return errors.New("uninstall command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
-				}
 				return unsafePluginNameErr(name)
 			}
 			klog.V(4).Infof("Going to uninstall plugin %s\n", name)

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -40,6 +41,9 @@ Remarks:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, name := range args {
 			if !validation.IsSafePluginName(name) {
+				if strings.Contains(name, "/") {
+					klog.Warningf("uninstall command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
+				}
 				return unsafePluginNameErr(name)
 			}
 			klog.V(4).Infof("Going to uninstall plugin %s\n", name)

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -41,8 +40,8 @@ Remarks:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, name := range args {
 			if !validation.IsSafePluginName(name) {
-				if strings.Contains(name, "/") {
-					klog.Warningf("uninstall command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
+				if isCanonicalName(name) {
+					return errors.New("uninstall command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
 				}
 				return unsafePluginNameErr(name)
 			}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -53,7 +53,7 @@ kubectl krew upgrade foo bar"`,
 					return errors.Wrap(err, "failed to find all installed versions")
 				}
 				for _, receipt := range installed {
-					pluginNames = append(pluginNames, receipt.Name)
+					pluginNames = append(pluginNames, receipt.Status.Source.Name+"/"+receipt.Name)
 				}
 				ignoreUpgraded = true
 				skipErrors = true

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -63,8 +63,7 @@ kubectl krew upgrade foo bar"`,
 				for _, arg := range args {
 					if isCanonicalName(arg) {
 						return errors.New("upgrade command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
-					}
-					if !validation.IsSafePluginName(arg) {
+					} else if !validation.IsSafePluginName(arg) {
 						return unsafePluginNameErr(arg)
 					}
 					r, err := receipt.Load(paths.PluginInstallReceiptPath(arg))

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -77,23 +77,24 @@ kubectl krew upgrade foo bar"`,
 					}
 				}
 
+				pluginDisplayName := displayName(plugin, indexName)
 				if err == nil {
-					fmt.Fprintf(os.Stderr, "Upgrading plugin: %s\n", name)
+					fmt.Fprintf(os.Stderr, "Upgrading plugin: %s\n", pluginDisplayName)
 					err = installation.Upgrade(paths, plugin, indexName)
 					if ignoreUpgraded && err == installation.ErrIsAlreadyUpgraded {
-						fmt.Fprintf(os.Stderr, "Skipping plugin %s, it is already on the newest version\n", name)
+						fmt.Fprintf(os.Stderr, "Skipping plugin %s, it is already on the newest version\n", pluginDisplayName)
 						continue
 					}
 				}
 				if err != nil {
 					nErrors++
 					if skipErrors {
-						fmt.Fprintf(os.Stderr, "WARNING: failed to upgrade plugin %q, skipping (error: %v)\n", name, err)
+						fmt.Fprintf(os.Stderr, "WARNING: failed to upgrade plugin %q, skipping (error: %v)\n", pluginDisplayName, err)
 						continue
 					}
-					return errors.Wrapf(err, "failed to upgrade plugin %q", name)
+					return errors.Wrapf(err, "failed to upgrade plugin %q", pluginDisplayName)
 				}
-				fmt.Fprintf(os.Stderr, "Upgraded plugin: %s\n", name)
+				fmt.Fprintf(os.Stderr, "Upgraded plugin: %s\n", pluginDisplayName)
 				internal.PrintSecurityNotice(plugin.Name)
 			}
 			if nErrors > 0 {

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -63,8 +62,8 @@ kubectl krew upgrade foo bar"`,
 				// Upgrade certain plugins
 				for _, arg := range args {
 					if !validation.IsSafePluginName(arg) {
-						if strings.Contains(arg, "/") {
-							klog.Warning("upgrade command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
+						if isCanonicalName(arg) {
+							return errors.New("upgrade command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
 						}
 						return unsafePluginNameErr(arg)
 					}

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -61,15 +61,15 @@ kubectl krew upgrade foo bar"`,
 			} else {
 				// Upgrade certain plugins
 				for _, arg := range args {
+					if isCanonicalName(arg) {
+						return errors.New("upgrade command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
+					}
 					if !validation.IsSafePluginName(arg) {
-						if isCanonicalName(arg) {
-							return errors.New("upgrade command does not support INDEX/PLUGIN syntax; just specify PLUGIN")
-						}
 						return unsafePluginNameErr(arg)
 					}
 					r, err := receipt.Load(paths.PluginInstallReceiptPath(arg))
 					if err != nil {
-						return errors.Wrapf(err, "receipt not found for %q", arg)
+						return errors.Wrapf(err, "read receipt %q", arg)
 					}
 					pluginNames = append(pluginNames, r.Status.Source.Name+"/"+r.Name)
 				}

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -47,6 +47,23 @@ func TestKrewUninstall(t *testing.T) {
 	}
 }
 
+func TestKrewUninstallPluginsFromCustomIndex(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
+	test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFail()
+	test.Krew("install", "foo/"+validPlugin).RunOrFail()
+
+	if _, err := test.Krew("uninstall", "foo/"+validPlugin).Run(); err == nil {
+		t.Error("expected error when uninstalling by canonical name")
+	}
+	test.Krew("uninstall", validPlugin).RunOrFail()
+	test.AssertExecutableNotInPATH("kubectl-" + validPlugin)
+}
+
 func TestKrewRemove_AliasSupported(t *testing.T) {
 	skipShort(t)
 

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -69,9 +69,17 @@ func TestKrewUpgradePluginsFromCustomIndex(t *testing.T) {
 	}
 
 	modifyManifestVersion(t, receipt, "v0.0.0")
-	out = string(test.Krew("upgrade", "foo/"+validPlugin).RunOrFailOutput())
+	out = string(test.Krew("upgrade", validPlugin).RunOrFailOutput())
 	if !strings.Contains(out, "Upgrading plugin: foo/"+validPlugin) {
 		t.Errorf("expected plugin foo/%s to be upgraded", validPlugin)
+	}
+
+	b, err := test.Krew("upgrade", "foo/"+validPlugin).Run()
+	if err == nil {
+		t.Error("expected error when using canonical name with upgrade")
+	}
+	if !strings.Contains(string(b), "INDEX/PLUGIN") {
+		t.Error("expected warning about using canonical name to be in output")
 	}
 }
 

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -73,6 +73,13 @@ func TestKrewUpgradePluginsFromCustomIndex(t *testing.T) {
 	if !strings.Contains(out, "Upgrading plugin: foo/"+validPlugin) {
 		t.Errorf("expected plugin foo/%s to be upgraded", validPlugin)
 	}
+}
+
+func TestKrewUpgrade_CannotUseIndexSyntax(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
 
 	b, err := test.Krew("upgrade", "foo/"+validPlugin).Run()
 	if err == nil {

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
@@ -47,6 +48,30 @@ func TestKrewUpgrade(t *testing.T) {
 
 	if initialLocation == eventualLocation {
 		t.Errorf("Expecting the plugin path to change but was the same.")
+	}
+}
+
+func TestKrewUpgradePluginsFromCustomIndex(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithIndex()
+	test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFail()
+	test.Krew("install", "foo/"+validPlugin).RunOrFail()
+
+	receipt := environment.NewPaths(test.Root()).PluginInstallReceiptPath(validPlugin)
+	modifyManifestVersion(t, receipt, "v0.0.0")
+	out := string(test.Krew("upgrade").RunOrFailOutput())
+	if !strings.Contains(out, "Upgrading plugin: foo/"+validPlugin) {
+		t.Errorf("expected plugin foo/%s to be upgraded", validPlugin)
+	}
+
+	modifyManifestVersion(t, receipt, "v0.0.0")
+	out = string(test.Krew("upgrade", "foo/"+validPlugin).RunOrFailOutput())
+	if !strings.Contains(out, "Upgrading plugin: foo/"+validPlugin) {
+		t.Errorf("expected plugin foo/%s to be upgraded", validPlugin)
 	}
 }
 


### PR DESCRIPTION
Upgrade was already refactored to support adding indexes to receipts so this was a pretty simple change + integration test. Upgrade works with:

- `kubectl krew upgrade`
- `kubectl krew upgrade plugin ... // plugin can be default/plugin or foo/plugin`

Also added warning text to uninstall when user tries to uninstall by canonical name.

Related issue: #566 
/area multi-index
<!-- For proposed features, make sure there's an issue it's discussed first -->
