### PR TITLE
multi-index: Add default index if none exists

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -189,7 +189,7 @@ Remarks:
 				klog.V(4).Infof("--no-update-index specified, skipping updating local copy of plugin index")
 				return nil
 			}
-			return ensureIndexesUpdated(cmd, args)
+			return ensureIndexes(cmd, args)
 		},
 	}
 

--- a/cmd/krew/cmd/system.go
+++ b/cmd/krew/cmd/system.go
@@ -51,7 +51,7 @@ This command will be removed without further notice from future versions of krew
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return receiptsmigration.Migrate(paths)
 	},
-	PreRunE: ensureIndexesUpdated,
+	PreRunE: func(_ *cobra.Command, _ []string) error { return ensureIndexesUpdated() },
 }
 
 var indexUpgradeCmd = &cobra.Command{

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -44,7 +44,7 @@ plugin index from the internet.
 Remarks:
   You don't need to run this command: Running "krew update" or "krew upgrade"
   will silently run this command.`,
-	RunE: ensureIndexesUpdated,
+	RunE: ensureIndexes,
 }
 
 func showFormattedPluginsInfo(out io.Writer, header string, plugins []string) {
@@ -120,7 +120,37 @@ func loadPlugins(indexes []indexoperations.Index) []pluginEntry {
 	return out
 }
 
-func ensureIndexesUpdated(_ *cobra.Command, _ []string) error {
+func ensureIndexes(_ *cobra.Command, _ []string) error {
+	if os.Getenv(constants.EnableMultiIndexSwitch) != "" {
+		klog.V(3).Infof("Will check if there are any indexes added.")
+		if err := ensureDefaultIndexIfNoneExist(); err != nil {
+			return err
+		}
+	}
+	return ensureIndexesUpdated()
+}
+
+// ensureDefaultIndexIfNoneExist adds the default index automatically
+// (and informs the user about it) if no plugin index exists for krew.
+func ensureDefaultIndexIfNoneExist() error {
+	idx, err := indexoperations.ListIndexes(paths)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve plugin indexes")
+	}
+	if len(idx) > 0 {
+		klog.V(3).Infof("Found %d indexes, skipping adding default index.", len(idx))
+		return nil
+	}
+
+	klog.V(3).Infof("No index found, add default index.")
+	fmt.Fprintf(os.Stderr, "Adding \"default\" plugin index from %s.\n", constants.DefaultIndexURI)
+	return errors.Wrap(indexoperations.AddIndex(paths, constants.DefaultIndexName, constants.DefaultIndexURI),
+		"failed to add default plugin index in absence of no indexes")
+}
+
+// ensureDefaultIndexIfNoneExist iterates over all indexes and updates them
+// and prints new plugins and upgrades available for installed plugins.
+func ensureIndexesUpdated() error {
 	indexes, err := indexoperations.ListIndexes(paths)
 	if err != nil {
 		return errors.Wrap(err, "failed to list indexes")

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -148,7 +148,7 @@ func ensureDefaultIndexIfNoneExist() error {
 		"failed to add default plugin index in absence of no indexes")
 }
 
-// ensureDefaultIndexIfNoneExist iterates over all indexes and updates them
+// ensureIndexesUpdated iterates over all indexes and updates them
 // and prints new plugins and upgrades available for installed plugins.
 func ensureIndexesUpdated() error {
 	indexes, err := indexoperations.ListIndexes(paths)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -106,7 +106,7 @@ kubectl krew upgrade foo bar"`,
 				klog.V(4).Infof("--no-update-index specified, skipping updating local copy of plugin index")
 				return nil
 			}
-			return ensureIndexesUpdated(cmd, args)
+			return ensureIndexes(cmd, args)
 		},
 	}
 


### PR DESCRIPTION
When user runs krew {install,update,upgrade} for the first time, if there are
no indexes, default index (with krew-index repo) is now automatically added.

Right now this code path only runs behind multi-index feature gate.

Related issue: #566
/assign @chriskim06
/area multi-index

<!-- For proposed features, make sure there's an issue it's discussed first -->