### PR TITLE
use kubetap homepage

### DIFF
--- a/cmd/generate-plugin-overview/generate-plugin-overview.go
+++ b/cmd/generate-plugin-overview/generate-plugin-overview.go
@@ -124,6 +124,7 @@ func findRepo(homePage string) string {
 		`https://kudo.dev/`:                                          "kudobuilder/kudo",
 		`https://kubevirt.io`:                                        "kubevirt/kubectl-virt-plugin",
 		`https://popeyecli.io`:                                       "derailed/popeye",
+		`https://soluble-ai.github.io/kubetap/`:                      "soluble-ai/kubetap",
 	}
 	return knownHomePages[homePage]
 }


### PR DESCRIPTION
Follow-up from @corneliusweig's [request in krew-index](https://github.com/kubernetes-sigs/krew-index/pull/623#issuecomment-636228575), I assume this change maps the name on [this page](https://github.com/kubernetes-sigs/krew-index/blob/master/plugins.md) to the project website (vs the code repo).

Cheers,🍻 