### PR TITLE
Redirect to Krew's new homepage in its manifest

### DIFF
--- a/cmd/generate-plugin-overview/generate-plugin-overview.go
+++ b/cmd/generate-plugin-overview/generate-plugin-overview.go
@@ -119,6 +119,7 @@ func findRepo(homePage string) string {
 	}
 
 	knownHomePages := map[string]string{
+		`https://krew.sigs.k8s.io/`:                                  "kubernetes-sigs/krew",
 		`https://sigs.k8s.io/krew`:                                   "kubernetes-sigs/krew",
 		`https://kubernetes.github.io/ingress-nginx/kubectl-plugin/`: "kubernetes/ingress-nginx",
 		`https://kudo.dev/`:                                          "kudobuilder/kudo",

--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -4,7 +4,7 @@ metadata:
   name: krew
 spec:
   version: "KREW_TAG"
-  homepage: https://sigs.k8s.io/krew
+  homepage: https://krew.sigs.k8s.io/
   shortDescription: Package manager for kubectl plugins.
   caveats: |
     krew is now installed! To start using kubectl plugins, you need to add
@@ -22,7 +22,8 @@ spec:
     For a full list of available plugins, run:
       $ kubectl krew search
 
-    You can find documentation at https://sigs.k8s.io/krew.
+    You can find documentation at
+      https://krew.sigs.k8s.io/docs/user-guide/quickstart/.
 
   platforms:
   - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz


### PR DESCRIPTION
So far, we have been redirecting to the github page. Our community page should be more useful in most cases however.
