### PR TITLE
Include filename in manifest validator

### DIFF
--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -63,7 +63,7 @@ func main() {
 }
 
 func validateManifestFile(path string) error {
-	klog.V(4).Infof("reading file %s", path)
+	klog.Infof("reading file %q", path)
 	p, err := indexscanner.ReadPluginFromFile(path)
 	if err != nil {
 		return errors.Wrap(err, "failed to read plugin file")


### PR DESCRIPTION
Otherwise it is impossible to determine which manifest failed, if
multiple manifests are changed.

