### PR TITLE
Use go1.14 in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,15 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goVer: [1.14]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go ${{ matrix.goVer }}
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ${{ matrix.goVer }}
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/krew
 
-go 1.13
+go 1.14
 
 require (
 	github.com/fatih/color v1.7.0

--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -23,7 +23,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
   echo >&2 'Installing golangci-lint'
   curl --silent --fail --location \
-    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.22.2
+    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.27.0
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
Also, bumps golangci-lint to v1.27.0 due to compatibility.

Fixes #606

