### PR TITLE
Print security notice when index is added

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -81,7 +81,8 @@ var indexAddCmd = &cobra.Command{
 		}
 		internal.PrintWarning(os.Stderr, `You have added a new index from %q
 The plugins in this index are not audited for security by the Krew maintainers.
-Install them at your own risk.`+"\n", args[1])
+Install them at your own risk.
+`, args[1])
 		return nil
 	},
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -76,12 +76,13 @@ var indexAddCmd = &cobra.Command{
 			return errInvalidIndexName
 		}
 		err := indexoperations.AddIndex(paths, name, args[1])
-		if err == nil {
-			internal.PrintWarning(os.Stderr, `You have added a new index from %q
+		if err != nil {
+			return err
+		}
+		internal.PrintWarning(os.Stderr, `You have added a new index from %q
 The plugins in this index are not audited for security by the Krew maintainers.
 Run them at your own risk.`+"\n", args[1])
-		}
-		return err
+		return nil
 	},
 }
 

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -81,7 +81,7 @@ var indexAddCmd = &cobra.Command{
 		}
 		internal.PrintWarning(os.Stderr, `You have added a new index from %q
 The plugins in this index are not audited for security by the Krew maintainers.
-Run them at your own risk.`+"\n", args[1])
+Install them at your own risk.`+"\n", args[1])
 		return nil
 	},
 }

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -75,7 +75,13 @@ var indexAddCmd = &cobra.Command{
 		if !indexoperations.IsValidIndexName(name) {
 			return errInvalidIndexName
 		}
-		return indexoperations.AddIndex(paths, name, args[1])
+		err := indexoperations.AddIndex(paths, name, args[1])
+		if err == nil {
+			internal.PrintWarning(os.Stderr, `You have added a new index from %q
+The plugins in this index are not audited for security by the Krew maintainers.
+Run them at your own risk.`+"\n", args[1])
+		}
+		return err
 	},
 }
 
@@ -86,7 +92,7 @@ var indexDeleteCmd = &cobra.Command{
 
 It is only safe to remove indexes without installed plugins. Removing an index
 while there are plugins installed will result in an error, unless the --force
-option is used ( not recommended).`,
+option is used (not recommended).`,
 
 	Args: cobra.ExactArgs(1),
 	RunE: indexDelete,

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/krew/internal/index/validation"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/pathutil"
+	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
 
@@ -173,7 +174,9 @@ Remarks:
 					output += fmt.Sprintf("Caveats:\n%s\n", indent(plugin.Spec.Caveats))
 				}
 				fmt.Fprintln(os.Stderr, indent(output))
-				internal.PrintSecurityNotice(plugin.Name)
+				if entry.indexName == constants.DefaultIndexName {
+					internal.PrintSecurityNotice(plugin.Name)
+				}
 			}
 			if len(failed) > 0 {
 				return errors.Wrapf(returnErr, "failed to install some plugins: %+v", failed)

--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/installation/receipt"
 	"sigs.k8s.io/krew/internal/pathutil"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func init() {
@@ -104,7 +105,9 @@ kubectl krew upgrade foo bar"`,
 					return errors.Wrapf(err, "failed to upgrade plugin %q", pluginDisplayName)
 				}
 				fmt.Fprintf(os.Stderr, "Upgraded plugin: %s\n", pluginDisplayName)
-				internal.PrintSecurityNotice(plugin.Name)
+				if indexName == constants.DefaultIndexName {
+					internal.PrintSecurityNotice(plugin.Name)
+				}
 			}
 			if nErrors > 0 {
 				fmt.Fprintf(os.Stderr, "WARNING: Some plugins failed to upgrade, check logs above.\n")

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -66,6 +66,19 @@ func TestKrewIndexAddUnsafe(t *testing.T) {
 	}
 }
 
+func TestKrewIndexAddShowsSecurityWarning(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	out := string(test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFailOutput())
+	if !strings.Contains(out, "WARNING") {
+		t.Errorf("expected output to contain warning when adding custom index: %v", out)
+	}
+}
+
 func TestKrewIndexList(t *testing.T) {
 	skipShort(t)
 

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -74,7 +74,7 @@ func TestKrewIndexAddShowsSecurityWarning(t *testing.T) {
 
 	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
 	out := string(test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFailOutput())
-	if !strings.Contains(out, "WARNING") {
+	if !strings.Contains(out, "WARNING: You have added a new index") {
 		t.Errorf("expected output to contain warning when adding custom index: %v", out)
 	}
 }

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -149,6 +149,19 @@ func TestKrewInstall_CustomIndex(t *testing.T) {
 	test.AssertExecutableNotInPATH("kubectl-" + validPlugin2)
 }
 
+func TestKrewInstallNoSecurityWarningForCustomIndex(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	out := string(test.Krew("install", "foo/"+validPlugin).RunOrFailOutput())
+	if strings.Contains(out, "Run them at your own risk") {
+		t.Errorf("expected install of custom plugin to not show security warning: %v", out)
+	}
+}
+
 func TestKrewInstall_Manifest(t *testing.T) {
 	skipShort(t)
 

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -74,6 +74,23 @@ func TestKrewUpgradePluginsFromCustomIndex(t *testing.T) {
 	}
 }
 
+func TestKrewUpgradeNoSecurityWarningForCustomIndex(t *testing.T) {
+	skipShort(t)
+
+	test, cleanup := NewTest(t)
+	defer cleanup()
+
+	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test.Krew("install", "foo/"+validPlugin).RunOrFail()
+
+	receipt := environment.NewPaths(test.Root()).PluginInstallReceiptPath(validPlugin)
+	modifyManifestVersion(t, receipt, "v0.0.1")
+	out := string(test.Krew("upgrade").RunOrFailOutput())
+	if strings.Contains(out, "Run them at your own risk") {
+		t.Errorf("expected install of custom plugin to not show security warning: %v", out)
+	}
+}
+
 func TestKrewUpgrade_CannotUseIndexSyntax(t *testing.T) {
 	skipShort(t)
 


### PR DESCRIPTION
Right now I have the warning when the index is added as:
```
WARNING: You have added a new index from "/home/kimc/playground/temp"
The plugins in this index are not audited for security by the Krew maintainers.
Install them at your own risk.
```

let me know if you guys think I should change this.

Fixes #615 
Related issue: #576

/area multi-index
<!-- For proposed features, make sure there's an issue it's discussed first -->
