### PR TITLE
Add more detail to error logging when dealing with bad index/plugin

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -54,7 +54,7 @@ Examples:
 		for _, idx := range indexes {
 			ps, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(idx.Name))
 			if err != nil {
-				return errors.Wrap(err, "failed to load the list of plugins from the index")
+				return errors.Wrapf(err, "failed to load the list of plugins from the index %q", idx.Name)
 			}
 			for _, p := range ps {
 				plugins = append(plugins, pluginEntry{p, idx.Name})

--- a/internal/index/indexscanner/scanner.go
+++ b/internal/index/indexscanner/scanner.go
@@ -117,7 +117,7 @@ func readFromFile(path string, as interface{}) error {
 		return err
 	}
 	err = decodeFile(f, &as)
-	return errors.Wrap(err, "failed to parse yaml file")
+	return errors.Wrapf(err, "failed to parse yaml file %q", path)
 }
 
 // decodeFile tries to decode a plugin/receipt


### PR DESCRIPTION
In addition to adding the index name to the search error output as mentioned in https://github.com/kubernetes-sigs/krew/issues/614#issuecomment-647662430, I added some more info when a plugin (or receipt, figured might as well) fails to parse in the case of there being bad yaml in a custom index. This wasn't mentioned in the issue so if you guys feel we shouldn't include it I can remove it.

Fixes #614 
<!-- For proposed features, make sure there's an issue it's discussed first -->

/area multi-index
/cc @ahmetb 
/cc @corneliusweig 