### PR TITLE
Remove multi index flag

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -35,11 +35,10 @@ var (
 
 // indexCmd represents the index command
 var indexCmd = &cobra.Command{
-	Use:    "index",
-	Short:  "Manage custom plugin indexes",
-	Long:   "Manage which repositories are used to discover and install plugins from.",
-	Args:   cobra.NoArgs,
-	Hidden: true, // TODO(chriskim06) remove this once multi-index is enabled
+	Use:   "index",
+	Short: "Manage custom plugin indexes",
+	Long:  "Manage which repositories are used to discover and install plugins from.",
+	Args:  cobra.NoArgs,
 }
 
 var indexListCmd = &cobra.Command{

--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -142,8 +142,5 @@ func init() {
 	indexCmd.AddCommand(indexAddCmd)
 	indexCmd.AddCommand(indexListCmd)
 	indexCmd.AddCommand(indexDeleteCmd)
-
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
-		rootCmd.AddCommand(indexCmd)
-	}
+	rootCmd.AddCommand(indexCmd)
 }

--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -36,7 +36,7 @@ var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Show information about an available plugin",
 	Long:  `Show detailed information about an available plugin.`,
-	Example: `kubectl krew info PLUGIN
+	Example: `  kubectl krew info PLUGIN
   kubectl krew info INDEX/PLUGIN`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		index, plugin := pathutil.CanonicalPluginName(args[0])

--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -28,16 +28,16 @@ import (
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/pathutil"
-	"sigs.k8s.io/krew/pkg/constants"
 	"sigs.k8s.io/krew/pkg/index"
 )
 
 // infoCmd represents the info command
 var infoCmd = &cobra.Command{
-	Use:     "info",
-	Short:   "Show information about an available plugin",
-	Long:    `Show detailed information about an available plugin.`,
-	Example: "kubectl krew info PLUGIN",
+	Use:   "info",
+	Short: "Show information about an available plugin",
+	Long:  `Show detailed information about an available plugin.`,
+	Example: `kubectl krew info PLUGIN
+  kubectl krew info INDEX/PLUGIN`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		index, plugin := pathutil.CanonicalPluginName(args[0])
 
@@ -95,10 +95,5 @@ func indent(s string) string {
 }
 
 func init() {
-	if os.Getenv(constants.EnableMultiIndexSwitch) != "" {
-		// TODO(ahmetb) move back into Example field above (with 2-space indent) once feature gate is removed.
-		infoCmd.Example += "\n  kubectl krew info INDEX/PLUGIN"
-	}
-
 	rootCmd.AddCommand(infoCmd)
 }

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -51,8 +51,11 @@ func init() {
 		Long: `Install one or multiple kubectl plugins.
 
 Examples:
-  To install one or multiple plugins, run:
+  To install one or multiple plugins from the default index, run:
     kubectl krew install NAME [NAME...]
+
+  To install one or multiple plugins from a custom index named "foo", run:
+    kubectl krew install foo/NAME [foo/NAME...]
 
   To install plugins from a newline-delimited file, run:
     kubectl krew install < file.txt

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -54,11 +54,11 @@ Examples:
   To install one or multiple plugins from the default index, run:
     kubectl krew install NAME [NAME...]
 
-  To install one or multiple plugins from a custom index, run:
-    kubectl krew install INDEX/NAME [INDEX/NAME...]
-
   To install plugins from a newline-delimited file, run:
     kubectl krew install < file.txt
+
+  To install one or multiple plugins from a custom index, run:
+    kubectl krew install INDEX/NAME [INDEX/NAME...]
 
   (For developers) To provide a custom plugin manifest, use the --manifest or
   --manifest-url arguments. Similarly, instead of downloading files from a URL,

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -54,8 +54,8 @@ Examples:
   To install one or multiple plugins from the default index, run:
     kubectl krew install NAME [NAME...]
 
-  To install one or multiple plugins from a custom index named "foo", run:
-    kubectl krew install foo/NAME [foo/NAME...]
+  To install one or multiple plugins from a custom index, run:
+    kubectl krew install INDEX/NAME [INDEX/NAME...]
 
   To install plugins from a newline-delimited file, run:
     kubectl krew install < file.txt
@@ -63,7 +63,7 @@ Examples:
   (For developers) To provide a custom plugin manifest, use the --manifest or
   --manifest-url arguments. Similarly, instead of downloading files from a URL,
   you can specify a local --archive file:
-	kubectl krew install --manifest=FILE [--archive=FILE]
+    kubectl krew install --manifest=FILE [--archive=FILE]
 
 Remarks:
   If a plugin is already installed, it will be skipped.

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -149,15 +149,13 @@ func preRun(cmd *cobra.Command, _ []string) error {
 		return errors.New("krew home outdated")
 	}
 
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
-		isMigrated, err := indexmigration.Done(paths)
-		if err != nil {
-			return errors.Wrap(err, "failed to check if index migration is complete")
-		}
-		if !isMigrated {
-			if err := indexmigration.Migrate(paths); err != nil {
-				return errors.Wrap(err, "index migration failed")
-			}
+	isMigrated, err = indexmigration.Done(paths)
+	if err != nil {
+		return errors.Wrap(err, "failed to check if index migration is complete")
+	}
+	if !isMigrated {
+		if err := indexmigration.Migrate(paths); err != nil {
+			return errors.Wrap(err, "index migration failed")
 		}
 	}
 

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -121,11 +121,9 @@ func loadPlugins(indexes []indexoperations.Index) []pluginEntry {
 }
 
 func ensureIndexes(_ *cobra.Command, _ []string) error {
-	if os.Getenv(constants.EnableMultiIndexSwitch) != "" {
-		klog.V(3).Infof("Will check if there are any indexes added.")
-		if err := ensureDefaultIndexIfNoneExist(); err != nil {
-			return err
-		}
+	klog.V(3).Infof("Will check if there are any indexes added.")
+	if err := ensureDefaultIndexIfNoneExist(); err != nil {
+		return err
 	}
 	return ensureIndexesUpdated()
 }
@@ -173,7 +171,7 @@ func ensureIndexesUpdated() error {
 			continue
 		}
 
-		if os.Getenv(constants.EnableMultiIndexSwitch) == "" || isDefaultIndex(idx.Name) {
+		if isDefaultIndex(idx.Name) {
 			fmt.Fprintln(os.Stderr, "Updated the local copy of plugin index.")
 		} else {
 			fmt.Fprintf(os.Stderr, "Updated the local copy of plugin index %q.\n", idx.Name)

--- a/hack/verify-index-migration.sh
+++ b/hack/verify-index-migration.sh
@@ -68,7 +68,6 @@ run_krew() {
   # TODO(chriskim06): remove multi index flag once feature gate is removed
   env KREW_ROOT="${krew_root}" \
     PATH="${krew_root}/bin:$PATH" \
-    X_KREW_ENABLE_MULTI_INDEX=1 \
     kubectl krew "$@"
 }
 

--- a/hack/verify-index-migration.sh
+++ b/hack/verify-index-migration.sh
@@ -65,7 +65,6 @@ run_krew() {
   krew_root="${1}"
   shift
 
-  # TODO(chriskim06): remove multi index flag once feature gate is removed
   env KREW_ROOT="${krew_root}" \
     PATH="${krew_root}/bin:$PATH" \
     kubectl krew "$@"

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -29,7 +29,7 @@ func TestKrewIndexAdd(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	if _, err := test.Krew("index", "add").Run(); err == nil {
 		t.Fatal("expected index add with no args to fail")
 	}
@@ -51,7 +51,7 @@ func TestKrewIndexAddUnsafe(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
 	defer cleanup()
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 
 	cases := []string{"a/b", `a\b`, "../a", `..\a`}
 	expected := "invalid index name"
@@ -72,7 +72,7 @@ func TestKrewIndexAddShowsSecurityWarning(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	out := string(test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFailOutput())
 	if !strings.Contains(out, "WARNING: You have added a new index") {
 		t.Errorf("expected output to contain warning when adding custom index: %v", out)
@@ -85,7 +85,7 @@ func TestKrewIndexList(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	out := test.Krew("index", "list").RunOrFailOutput()
 	if indexes := lines(out); len(indexes) < 2 {
 		// the first line is the header
@@ -106,7 +106,7 @@ func TestKrewIndexList_NoIndexes(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	index := test.TempDir().Path("index")
 	if err := os.RemoveAll(index); err != nil {
 		t.Fatalf("error removing default index: %v", err)
@@ -122,7 +122,6 @@ func TestKrewIndexList_NoIndexes(t *testing.T) {
 func TestKrewIndexRemove_nonExisting(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
 	_, err := test.Krew("index", "remove", "non-existing").Run()
@@ -134,7 +133,7 @@ func TestKrewIndexRemove_nonExisting(t *testing.T) {
 func TestKrewIndexRemove_ok(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	defer cleanup()
 
 	test.Krew("index", "remove", "foo").RunOrFail()
@@ -143,7 +142,7 @@ func TestKrewIndexRemove_ok(t *testing.T) {
 func TestKrewIndexRemove_unsafe(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	defer cleanup()
 
 	expected := "invalid index name"
@@ -161,7 +160,7 @@ func TestKrewIndexRemove_unsafe(t *testing.T) {
 func TestKrewIndexRemoveFailsWhenPluginsInstalled(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	defer cleanup()
 
 	test.Krew("install", validPlugin).RunOrFailOutput()
@@ -176,7 +175,6 @@ func TestKrewIndexRemoveFailsWhenPluginsInstalled(t *testing.T) {
 func TestKrewIndexRemoveForce_nonExisting(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
 	// --force returns success for non-existing indexes
@@ -186,7 +184,6 @@ func TestKrewIndexRemoveForce_nonExisting(t *testing.T) {
 func TestKrewDefaultIndex_notAutomaticallyAdded(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
 	test.Krew("help").RunOrFail()
@@ -203,7 +200,6 @@ func TestKrewDefaultIndex_notAutomaticallyAdded(t *testing.T) {
 func TestKrewDefaultIndex_AutoAddedOnInstall(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
 	test.Krew("install", validPlugin).RunOrFail()
@@ -213,7 +209,6 @@ func TestKrewDefaultIndex_AutoAddedOnInstall(t *testing.T) {
 func TestKrewDefaultIndex_AutoAddedOnUpdate(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
 	test.Krew("update").RunOrFail()
@@ -223,7 +218,6 @@ func TestKrewDefaultIndex_AutoAddedOnUpdate(t *testing.T) {
 func TestKrewDefaultIndex_AutoAddedOnUpgrade(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1)
 	defer cleanup()
 
 	test.Krew("upgrade").RunOrFail()

--- a/integration_test/info_test.go
+++ b/integration_test/info_test.go
@@ -17,8 +17,6 @@ package integrationtest
 import (
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestKrewInfo(t *testing.T) {
@@ -53,7 +51,7 @@ func TestKrewInfoCustomIndex(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
 
 	out := string(test.Krew("info", "foo/"+validPlugin).RunOrFailOutput())

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -62,7 +62,7 @@ func TestKrewInstallUnsafe(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
 	defer cleanup()
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 
 	cases := []string{
 		`../index/` + validPlugin,
@@ -138,7 +138,7 @@ func TestKrewInstall_CustomIndex(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
 	test.AssertPluginFromIndex(validPlugin, "foo")
@@ -155,7 +155,7 @@ func TestKrewInstallNoSecurityWarningForCustomIndex(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	out := string(test.Krew("install", "foo/"+validPlugin).RunOrFailOutput())
 	if strings.Contains(out, "Run them at your own risk") {
 		t.Errorf("expected install of custom plugin to not show security warning: %v", out)

--- a/integration_test/list_test.go
+++ b/integration_test/list_test.go
@@ -15,7 +15,6 @@
 package integrationtest
 
 import (
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ func TestKrewList(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	initialList := test.Krew("list").RunOrFailOutput()
 	initialOut := []byte{'\n'}
 
@@ -66,9 +65,7 @@ func TestKrewListSorted(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
+	test = test.WithDefaultIndex()
 
 	paths := environment.NewPaths(test.Root())
 	ps, err := indexscanner.LoadPluginListFromFS(paths.IndexPluginsPath(constants.DefaultIndexName))

--- a/integration_test/migration_test.go
+++ b/integration_test/migration_test.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestKrewIndexAutoMigration(t *testing.T) {
@@ -29,7 +27,7 @@ func TestKrewIndexAutoMigration(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	prepareOldIndexLayout(test)
 
 	// any command here should cause the index migration to occur

--- a/integration_test/search_test.go
+++ b/integration_test/search_test.go
@@ -19,8 +19,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestKrewSearchAll(t *testing.T) {
@@ -54,7 +52,7 @@ func TestKrewSearchOne(t *testing.T) {
 func TestKrewSearchMultiIndex(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	defer cleanup()
 
 	test.Krew("install", validPlugin).RunOrFail()
@@ -77,7 +75,7 @@ func TestKrewSearchMultiIndex(t *testing.T) {
 func TestKrewSearchMultiIndexSortedByDisplayName(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	defer cleanup()
 
 	output := string(test.Krew("search").RunOrFailOutput())

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -53,7 +53,7 @@ func TestKrewUninstallPluginsFromCustomIndex(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
+	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
 
 	test.Krew("uninstall", validPlugin).RunOrFail()
@@ -66,7 +66,7 @@ func TestKrewUninstall_CannotUseIndexSyntax(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	out, err := test.Krew("uninstall", "foo/"+validPlugin).Run()
 	if err == nil {
 		t.Error("expected error when uninstalling by canonical name")
@@ -110,7 +110,7 @@ func TestKrewRemove_Unsafe(t *testing.T) {
 	skipShort(t)
 	test, cleanup := NewTest(t)
 	defer cleanup()
-	test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
+	test.WithDefaultIndex()
 	test.Krew("install", validPlugin).RunOrFailOutput()
 
 	cases := []string{

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -54,10 +54,7 @@ func TestKrewUpdateMultipleIndexes(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex().WithCustomIndexFromDefault("foo")
-	// to enable new paths in environment.NewPaths()
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
+	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 
 	paths := environment.NewPaths(test.Root())
 	if err := os.RemoveAll(paths.IndexPluginsPath("foo")); err != nil {
@@ -78,9 +75,7 @@ func TestKrewUpdateFailedIndex(t *testing.T) {
 	test, cleanup := NewTest(t)
 	defer cleanup()
 
-	test = test.WithEnv(constants.EnableMultiIndexSwitch, 1).WithDefaultIndex()
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
+	test = test.WithDefaultIndex()
 
 	paths := environment.NewPaths(test.Root())
 	test.TempDir().InitEmptyGitRepo(paths.IndexPath("foo"), "invalid-git")

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -44,13 +44,15 @@ func TestKrewUpgrade(t *testing.T) {
 	test.WithDefaultIndex().
 		Krew("install", "--manifest", filepath.Join("testdata", validPlugin+constants.ManifestExtension)).
 		RunOrFail()
+
+	// plugins installed via manifest get the special "detached" index so this needs to
+	// be changed to default in order for it to be upgraded here
 	receipt := environment.NewPaths(test.Root()).PluginInstallReceiptPath(validPlugin)
 	modifyReceiptIndex(t, receipt, "default")
-	initialLocation := resolvePluginSymlink(test, validPlugin)
 
+	initialLocation := resolvePluginSymlink(test, validPlugin)
 	test.Krew("upgrade").RunOrFail()
 	eventualLocation := resolvePluginSymlink(test, validPlugin)
-
 	if initialLocation == eventualLocation {
 		t.Errorf("Expecting the plugin path to change but was the same.")
 	}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -61,19 +61,12 @@ func (p Paths) IndexBase() string {
 }
 
 // IndexPath returns the directory where a plugin index repository is cloned.
-// When constants.EnableMultiIndexSwitch var is unset it just returns the krew
-// index base.
 // e.g. {BasePath}/index/default or {BasePath}/index
 func (p Paths) IndexPath(name string) string {
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); ok {
-		return filepath.Join(p.base, "index", name)
-	}
-	return p.IndexBase()
+	return filepath.Join(p.base, "index", name)
 }
 
 // IndexPluginsPath returns the plugins directory of an index repository.
-// When constants.EnableMultiIndexSwitch var is unset it just returns the old
-// structure krew-index plugins.
 // e.g. {BasePath}/index/default/plugins/ or {BasePath}/index/plugins/
 func (p Paths) IndexPluginsPath(name string) string {
 	return filepath.Join(p.IndexPath(name), "plugins")

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -56,24 +56,12 @@ func TestPaths(t *testing.T) {
 		t.Errorf("BinPath()=%s; expected=%s", got, expected)
 	}
 
-	t.Run("with EnableMultiIndexSwitch", func(t *testing.T) {
-		os.Setenv(constants.EnableMultiIndexSwitch, "1")
-		defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-		if got, expected := p.IndexPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/default"); got != expected {
-			t.Errorf("IndexPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
-		}
-		if got, expected := p.IndexPluginsPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
-		}
-	})
-	t.Run("without EnableMultiIndexSwitch", func(t *testing.T) {
-		if got, expected := p.IndexPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index"); got != expected {
-			t.Errorf("IndexPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
-		}
-		if got, expected := p.IndexPluginsPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/plugins"); got != expected {
-			t.Errorf("IndexPluginsPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
-		}
-	})
+	if got, expected := p.IndexPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/default"); got != expected {
+		t.Errorf("IndexPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
+	}
+	if got, expected := p.IndexPluginsPath(constants.DefaultIndexName), filepath.FromSlash("/foo/index/default/plugins"); got != expected {
+		t.Errorf("IndexPluginsPath(\"%s\")=%s; expected=%s", constants.DefaultIndexName, got, expected)
+	}
 
 	if got, expected := p.InstallPath(), filepath.FromSlash("/foo/store"); got != expected {
 		t.Errorf("InstallPath()=%s; expected=%s", got, expected)

--- a/internal/index/indexoperations/index.go
+++ b/internal/index/indexoperations/index.go
@@ -23,7 +23,6 @@ import (
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/gitutil"
-	"sigs.k8s.io/krew/pkg/constants"
 )
 
 var validNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -37,15 +36,6 @@ type Index struct {
 // ListIndexes returns a slice of Index objects. The path argument is used as
 // the base path of the index.
 func ListIndexes(paths environment.Paths) ([]Index, error) {
-	if _, ok := os.LookupEnv(constants.EnableMultiIndexSwitch); !ok {
-		return []Index{
-			{
-				Name: constants.DefaultIndexName,
-				URL:  constants.DefaultIndexURI,
-			},
-		}, nil
-	}
-
 	dirs, err := ioutil.ReadDir(paths.IndexBase())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list directory")

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -23,14 +23,9 @@ import (
 
 	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/internal/testutil"
-	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestListIndexes(t *testing.T) {
-	// TODO remove after index integration feature gate is no longer neeeded
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
 
@@ -61,10 +56,6 @@ func TestListIndexes(t *testing.T) {
 }
 
 func TestAddIndexSuccess(t *testing.T) {
-	// TODO remove after index integration feature gate is no longer neeeded
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
 
@@ -92,10 +83,6 @@ func TestAddIndexSuccess(t *testing.T) {
 }
 
 func TestAddIndexFailure(t *testing.T) {
-	// TODO remove after index integration feature gate is no longer neeeded
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
 
@@ -119,10 +106,6 @@ func TestAddIndexFailure(t *testing.T) {
 }
 
 func TestDeleteIndex(t *testing.T) {
-	// TODO(ahmetb) remove multi-index gate once it's fully integrated
-	os.Setenv(constants.EnableMultiIndexSwitch, "1")
-	defer os.Unsetenv(constants.EnableMultiIndexSwitch)
-
 	// root directory does not exist
 	if err := DeleteIndex(environment.NewPaths(filepath.FromSlash("/tmp/does-not-exist/foo")), "bar"); err == nil {
 		t.Fatal("expected error")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,7 +24,4 @@ const (
 	DefaultIndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
 	// DefaultIndexName is a magic string that's used for a plugin name specified without an index.
 	DefaultIndexName = "default"
-	// EnableMultiIndexSwitch is the name of the environment variable that needs to be set to use
-	// the features around multiple indexes (this will be removed later on).
-	EnableMultiIndexSwitch = "X_KREW_ENABLE_MULTI_INDEX"
 )


### PR DESCRIPTION
Changes:
- remove the multi index flag
- update the `install` help message with an example for installing from a custom index
- update integration test function `WithDefaultIndex` to create an index in the migrated layout

Fixes #597 
Related issue: #566 

/area multi-index
/cc @ahmetb 
/cc @corneliusweig 
<!-- For proposed features, make sure there's an issue it's discussed first -->
