### PR TITLE
Use environment.Paths instead of calculating paths in integration tests

### DIFF
--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/krew/internal/environment"
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
@@ -39,10 +40,11 @@ func TestKrewIndexAdd(t *testing.T) {
 	if err := test.Krew("index", "add", "../../usr/bin", constants.DefaultIndexURI); err == nil {
 		t.Fatal("expected index add with path characters to fail")
 	}
-	if _, err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err != nil {
+	index := environment.NewPaths(test.Root()).IndexPath(constants.DefaultIndexName)
+	if _, err := test.Krew("index", "add", "foo", index).Run(); err != nil {
 		t.Fatalf("error adding new index: %v", err)
 	}
-	if _, err := test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).Run(); err == nil {
+	if _, err := test.Krew("index", "add", "foo", index).Run(); err == nil {
 		t.Fatal("expected adding same index to fail")
 	}
 }
@@ -73,7 +75,8 @@ func TestKrewIndexAddShowsSecurityWarning(t *testing.T) {
 	defer cleanup()
 
 	test.WithDefaultIndex()
-	out := string(test.Krew("index", "add", "foo", test.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFailOutput())
+	index := environment.NewPaths(test.Root()).IndexPath(constants.DefaultIndexName)
+	out := string(test.Krew("index", "add", "foo", index).RunOrFailOutput())
 	if !strings.Contains(out, "WARNING: You have added a new index") {
 		t.Errorf("expected output to contain warning when adding custom index: %v", out)
 	}
@@ -107,7 +110,7 @@ func TestKrewIndexList_NoIndexes(t *testing.T) {
 	defer cleanup()
 
 	test.WithDefaultIndex()
-	index := test.TempDir().Path("index")
+	index := environment.NewPaths(test.Root()).IndexBase()
 	if err := os.RemoveAll(index); err != nil {
 		t.Fatalf("error removing default index: %v", err)
 	}

--- a/integration_test/migration_test.go
+++ b/integration_test/migration_test.go
@@ -19,6 +19,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/krew/internal/environment"
+	"sigs.k8s.io/krew/pkg/constants"
 )
 
 func TestKrewIndexAutoMigration(t *testing.T) {
@@ -59,16 +62,17 @@ func TestKrewUnsupportedVersion(t *testing.T) {
 }
 
 func isIndexMigrated(it *ITest) bool {
-	indexPath := it.TempDir().Path("index/default")
+	indexPath := environment.NewPaths(it.Root()).IndexPath(constants.DefaultIndexName)
 	_, err := os.Stat(indexPath)
 	return err == nil
 }
 
 // TODO remove when testing indexmigration is no longer necessary
 func prepareOldIndexLayout(it *ITest) {
-	indexPath := it.TempDir().Path("index/default")
+	paths := environment.NewPaths(it.Root())
+	indexPath := paths.IndexPath(constants.DefaultIndexName)
 	tmpPath := it.TempDir().Path("tmp_index")
-	newPath := it.TempDir().Path("index")
+	newPath := paths.IndexBase()
 	if err := os.Rename(indexPath, tmpPath); err != nil {
 		it.t.Fatal(err)
 	}

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -192,7 +192,8 @@ func (it *ITest) WithDefaultIndex() *ITest {
 // to be called before this function. This is a helper function for working with custom indexes in the
 // integration tests so that developers don't need to alias the cloned default index each time.
 func (it *ITest) WithCustomIndexFromDefault(name string) *ITest {
-	it.Krew("index", "add", name, it.TempDir().Path("index/"+constants.DefaultIndexName)).RunOrFail()
+	indexPath := environment.NewPaths(it.Root()).IndexPath(constants.DefaultIndexName)
+	it.Krew("index", "add", name, indexPath).RunOrFail()
 	return it
 }
 

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -173,7 +173,8 @@ func TestKrewUpgrade_ValidPluginInstalledFromManifest(t *testing.T) {
 		Krew("install", validPlugin).
 		RunOrFail()
 
-	validPluginPath := filepath.Join(test.Root(), "index", "default", "plugins", validPlugin+constants.ManifestExtension)
+	pluginPath := environment.NewPaths(test.Root()).IndexPluginsPath(constants.DefaultIndexName)
+	validPluginPath := filepath.Join(pluginPath, validPlugin+constants.ManifestExtension)
 	if err := os.Remove(validPluginPath); err != nil {
 		t.Fatalf("can't remove valid plugin from index: %q", validPluginPath)
 	}


### PR DESCRIPTION
Fixes #562 

/area multi-index
/cc @ahmetb 
/cc @corneliusweig 
<!-- For proposed features, make sure there's an issue it's discussed first -->
