### PR TITLE
fix path warning on windows

### DIFF
--- a/cmd/krew/cmd/internal/setup_check.go
+++ b/cmd/krew/cmd/internal/setup_check.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	instructionWindows = `To be able to run kubectl plugins, you need to add the
-"%USERPROFILE%\.krew\bin" directory to your PATH environment variable
+"%%USERPROFILE%%\.krew\bin" directory to your PATH environment variable
 and restart your shell.`
 	instructionUnixTemplate = `To be able to run kubectl plugins, you need to add
 the following to your %s

--- a/cmd/krew/cmd/internal/setup_check_test.go
+++ b/cmd/krew/cmd/internal/setup_check_test.go
@@ -45,7 +45,7 @@ func TestIsBinDirInPATH_secondRun(t *testing.T) {
 }
 
 func TestSetupInstructions_windows(t *testing.T) {
-	const instructionsContain = "add the\n\"%USERPROFILE%\\.krew\\bin\" directory to your PATH environment variable"
+	const instructionsContain = `USERPROFILE`
 	os.Setenv("KREW_OS", "windows")
 	defer func() { os.Unsetenv("KREW_OS") }()
 	instructions := SetupInstructions()


### PR DESCRIPTION
Previously this was rendering as

    %!U(MISSING)SERPROFILE%!\(MISSING).krew\bin

while installing on windows. Using %% solves that.