### PR TITLE
Use go 1.14 `t.Cleanup()` for simpler tests

### DIFF
--- a/cmd/krew/cmd/internal/setup_check_test.go
+++ b/cmd/krew/cmd/internal/setup_check_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestIsBinDirInPATH_firstRun(t *testing.T) {
-	tempDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tempDir := testutil.NewTempDir(t)
 
 	paths := environment.NewPaths(tempDir.Path("does-not-exist"))
 	res := IsBinDirInPATH(paths)
@@ -35,8 +34,8 @@ func TestIsBinDirInPATH_firstRun(t *testing.T) {
 }
 
 func TestIsBinDirInPATH_secondRun(t *testing.T) {
-	tempDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tempDir := testutil.NewTempDir(t)
+
 	paths := environment.NewPaths(tempDir.Root())
 	res := IsBinDirInPATH(paths)
 	if res == true {

--- a/cmd/validate-krew-manifest/main_test.go
+++ b/cmd/validate-krew-manifest/main_test.go
@@ -82,8 +82,7 @@ func TestValidateManifestFile(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmp, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmp := testutil.NewTempDir(t)
 
 			if test.writeManifest {
 				content, err := yaml.Marshal(test.plugin)

--- a/integration_test/commandline_test.go
+++ b/integration_test/commandline_test.go
@@ -19,8 +19,7 @@ import "testing"
 func TestUnknownCommand(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	if _, err := test.Krew("foobar").Run(); err == nil {
 		t.Errorf("Expected `krew foobar` to fail")

--- a/integration_test/help_test.go
+++ b/integration_test/help_test.go
@@ -22,8 +22,7 @@ import (
 func TestKrewHelp(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew().RunOrFail() // no args
 	test.Krew("help").RunOrFail()
@@ -33,8 +32,7 @@ func TestKrewHelp(t *testing.T) {
 
 func TestRootHelpShowsKubectlPrefix(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	out := string(test.Krew("help").RunOrFailOutput())
 

--- a/integration_test/index_test.go
+++ b/integration_test/index_test.go
@@ -27,8 +27,7 @@ import (
 func TestKrewIndexAdd(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex()
 	if _, err := test.Krew("index", "add").Run(); err == nil {
@@ -51,8 +50,7 @@ func TestKrewIndexAdd(t *testing.T) {
 
 func TestKrewIndexAddUnsafe(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	test.WithDefaultIndex()
 
 	cases := []string{"a/b", `a\b`, "../a", `..\a`}
@@ -71,8 +69,7 @@ func TestKrewIndexAddUnsafe(t *testing.T) {
 func TestKrewIndexAddShowsSecurityWarning(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex()
 	index := environment.NewPaths(test.Root()).IndexPath(constants.DefaultIndexName)
@@ -85,8 +82,7 @@ func TestKrewIndexAddShowsSecurityWarning(t *testing.T) {
 func TestKrewIndexList(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex()
 	out := test.Krew("index", "list").RunOrFailOutput()
@@ -106,8 +102,7 @@ func TestKrewIndexList(t *testing.T) {
 func TestKrewIndexList_NoIndexes(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex()
 	index := environment.NewPaths(test.Root()).IndexBase()
@@ -124,8 +119,7 @@ func TestKrewIndexList_NoIndexes(t *testing.T) {
 
 func TestKrewIndexRemove_nonExisting(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	_, err := test.Krew("index", "remove", "non-existing").Run()
 	if err == nil {
@@ -135,18 +129,16 @@ func TestKrewIndexRemove_nonExisting(t *testing.T) {
 
 func TestKrewIndexRemove_ok(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
+	test := NewTest(t)
 	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
-	defer cleanup()
 
 	test.Krew("index", "remove", "foo").RunOrFail()
 }
 
 func TestKrewIndexRemove_unsafe(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
+	test := NewTest(t)
 	test.WithDefaultIndex()
-	defer cleanup()
 
 	expected := "invalid index name"
 	cases := []string{"a/b", `a\b`, "../a", `..\a`}
@@ -162,9 +154,8 @@ func TestKrewIndexRemove_unsafe(t *testing.T) {
 
 func TestKrewIndexRemoveFailsWhenPluginsInstalled(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
+	test := NewTest(t)
 	test.WithDefaultIndex()
-	defer cleanup()
 
 	test.Krew("install", validPlugin).RunOrFailOutput()
 	if _, err := test.Krew("index", "remove", "default").Run(); err == nil {
@@ -177,8 +168,7 @@ func TestKrewIndexRemoveFailsWhenPluginsInstalled(t *testing.T) {
 
 func TestKrewIndexRemoveForce_nonExisting(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	// --force returns success for non-existing indexes
 	test.Krew("index", "remove", "--force", "non-existing").RunOrFail()
@@ -186,8 +176,7 @@ func TestKrewIndexRemoveForce_nonExisting(t *testing.T) {
 
 func TestKrewDefaultIndex_notAutomaticallyAdded(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("help").RunOrFail()
 	out, err := test.Krew("search").Run()
@@ -202,8 +191,7 @@ func TestKrewDefaultIndex_notAutomaticallyAdded(t *testing.T) {
 
 func TestKrewDefaultIndex_AutoAddedOnInstall(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("install", validPlugin).RunOrFail()
 	ensureIndexListHasDefaultIndex(t, string(test.Krew("index", "list").RunOrFailOutput()))
@@ -211,8 +199,7 @@ func TestKrewDefaultIndex_AutoAddedOnInstall(t *testing.T) {
 
 func TestKrewDefaultIndex_AutoAddedOnUpdate(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("update").RunOrFail()
 	ensureIndexListHasDefaultIndex(t, string(test.Krew("index", "list").RunOrFailOutput()))
@@ -220,8 +207,7 @@ func TestKrewDefaultIndex_AutoAddedOnUpdate(t *testing.T) {
 
 func TestKrewDefaultIndex_AutoAddedOnUpgrade(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("upgrade").RunOrFail()
 	ensureIndexListHasDefaultIndex(t, string(test.Krew("index", "list").RunOrFailOutput()))

--- a/integration_test/info_test.go
+++ b/integration_test/info_test.go
@@ -22,8 +22,7 @@ import (
 func TestKrewInfo(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	out := string(test.WithDefaultIndex().Krew("info", validPlugin).RunOrFailOutput())
 	expected := `INDEX: default`
@@ -35,8 +34,7 @@ func TestKrewInfo(t *testing.T) {
 func TestKrewInfoInvalidPlugin(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	plugin := "invalid-plugin"
 	_, err := test.WithDefaultIndex().Krew("info", plugin).Run()
@@ -48,8 +46,7 @@ func TestKrewInfoInvalidPlugin(t *testing.T) {
 func TestKrewInfoCustomIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -30,8 +30,7 @@ const (
 
 func TestKrewInstall(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	if err := test.Krew("install", validPlugin); err == nil {
 		t.Fatal("expected to fail without initializing the index")
@@ -49,8 +48,7 @@ func TestKrewInstall(t *testing.T) {
 
 func TestKrewInstallReRun(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex()
 	test.Krew("install", validPlugin).RunOrFail()
@@ -60,8 +58,7 @@ func TestKrewInstallReRun(t *testing.T) {
 
 func TestKrewInstallUnsafe(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	test.WithDefaultIndex()
 
 	cases := []string{
@@ -86,8 +83,7 @@ func TestKrewInstallUnsafe(t *testing.T) {
 func TestKrewInstall_MultiplePositionalArgs(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().Krew("install", validPlugin, validPlugin2).RunOrFailOutput()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
@@ -97,8 +93,7 @@ func TestKrewInstall_MultiplePositionalArgs(t *testing.T) {
 func TestKrewInstall_Stdin(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().WithStdin(strings.NewReader(validPlugin + "\n" + validPlugin2)).
 		Krew("install").RunOrFailOutput()
@@ -110,8 +105,7 @@ func TestKrewInstall_Stdin(t *testing.T) {
 func TestKrewInstall_StdinAndPositionalArguments(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	// when stdin is detected, it's ignored in favor of positional arguments
 	test.WithDefaultIndex().
@@ -124,8 +118,7 @@ func TestKrewInstall_StdinAndPositionalArguments(t *testing.T) {
 func TestKrewInstall_ExplicitDefaultIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("install", "default/"+validPlugin).RunOrFail()
 	test.AssertExecutableInPATH("kubectl-" + validPlugin)
@@ -135,8 +128,7 @@ func TestKrewInstall_ExplicitDefaultIndex(t *testing.T) {
 func TestKrewInstall_CustomIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
@@ -152,8 +144,7 @@ func TestKrewInstall_CustomIndex(t *testing.T) {
 func TestKrewInstallNoSecurityWarningForCustomIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	out := string(test.Krew("install", "foo/"+validPlugin).RunOrFailOutput())
@@ -165,8 +156,7 @@ func TestKrewInstallNoSecurityWarningForCustomIndex(t *testing.T) {
 func TestKrewInstall_Manifest(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("install",
 		"--manifest", filepath.Join("testdata", validPlugin+constants.ManifestExtension)).
@@ -178,8 +168,7 @@ func TestKrewInstall_Manifest(t *testing.T) {
 func TestKrewInstall_ManifestURL(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	srv, shutdown := localTestServer()
 	defer shutdown()
 
@@ -193,8 +182,7 @@ func TestKrewInstall_ManifestURL(t *testing.T) {
 func TestKrewInstall_ManifestAndArchive(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.Krew("install",
 		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),
@@ -207,8 +195,7 @@ func TestKrewInstall_ManifestAndArchive(t *testing.T) {
 func TestKrewInstall_OnlyArchive(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	_, err := test.Krew("install",
 		"--archive", filepath.Join("testdata", fooPlugin+".tar.gz")).
@@ -221,8 +208,7 @@ func TestKrewInstall_OnlyArchive(t *testing.T) {
 func TestKrewInstall_ManifestArgsAreMutuallyExclusive(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	srv, shutdown := localTestServer()
 	defer shutdown()
 
@@ -237,8 +223,7 @@ func TestKrewInstall_ManifestArgsAreMutuallyExclusive(t *testing.T) {
 func TestKrewInstall_NoManifestArgsWhenPositionalArgsSpecified(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	_, err := test.Krew("install", validPlugin,
 		"--manifest", filepath.Join("testdata", fooPlugin+constants.ManifestExtension),

--- a/integration_test/list_test.go
+++ b/integration_test/list_test.go
@@ -32,8 +32,7 @@ import (
 func TestKrewList(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	initialList := test.Krew("list").RunOrFailOutput()
@@ -62,8 +61,7 @@ func TestKrewList(t *testing.T) {
 
 func TestKrewListSorted(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex()
 

--- a/integration_test/migration_test.go
+++ b/integration_test/migration_test.go
@@ -27,8 +27,7 @@ import (
 func TestKrewIndexAutoMigration(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex()
 	prepareOldIndexLayout(test)
@@ -43,8 +42,7 @@ func TestKrewIndexAutoMigration(t *testing.T) {
 func TestKrewUnsupportedVersion(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().Krew("install", validPlugin).RunOrFail()
 

--- a/integration_test/search_test.go
+++ b/integration_test/search_test.go
@@ -24,8 +24,7 @@ import (
 func TestKrewSearchAll(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	output := test.WithDefaultIndex().Krew("search").RunOrFailOutput()
 	if plugins := lines(output); len(plugins) < 10 {
@@ -37,8 +36,7 @@ func TestKrewSearchAll(t *testing.T) {
 func TestKrewSearchOne(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	plugins := lines(test.WithDefaultIndex().Krew("search", "krew").RunOrFailOutput())
 	if len(plugins) < 2 {
@@ -51,9 +49,8 @@ func TestKrewSearchOne(t *testing.T) {
 
 func TestKrewSearchMultiIndex(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
+	test := NewTest(t)
 	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
-	defer cleanup()
 
 	test.Krew("install", validPlugin).RunOrFail()
 	test.Krew("install", "foo/"+validPlugin2).RunOrFail()
@@ -74,9 +71,8 @@ func TestKrewSearchMultiIndex(t *testing.T) {
 
 func TestKrewSearchMultiIndexSortedByDisplayName(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
+	test := NewTest(t)
 	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
-	defer cleanup()
 
 	output := string(test.Krew("search").RunOrFailOutput())
 

--- a/integration_test/testutil_test.go
+++ b/integration_test/testutil_test.go
@@ -60,8 +60,8 @@ type ITest struct {
 }
 
 // NewTest creates a fluent krew ITest.
-func NewTest(t *testing.T) (*ITest, func()) {
-	tempDir, cleanup := testutil.NewTempDir(t)
+func NewTest(t *testing.T) *ITest {
+	tempDir := testutil.NewTempDir(t)
 	binDir := setupKrewBin(t, tempDir)
 
 	return &ITest{
@@ -75,7 +75,7 @@ func NewTest(t *testing.T) (*ITest, func()) {
 			"KREW_NO_UPGRADE_CHECK=1",
 		},
 		tempDir: tempDir,
-	}, cleanup
+	}
 }
 
 // setupKrewBin symlinks the $KREW_BINARY to $tempDir/bin and returns the path
@@ -309,8 +309,7 @@ func (it *ITest) initializeIndex() {
 
 func initFromGitClone(t *testing.T) ([]byte, error) {
 	const tarName = "index.tar"
-	indexDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	indexDir := testutil.NewTempDir(t)
 	indexRoot := indexDir.Root()
 
 	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", "--no-tags", constants.DefaultIndexURI)

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -27,8 +27,7 @@ import (
 func TestKrewUninstall(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex()
 
@@ -50,8 +49,7 @@ func TestKrewUninstall(t *testing.T) {
 func TestKrewUninstallPluginsFromCustomIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
@@ -63,8 +61,7 @@ func TestKrewUninstallPluginsFromCustomIndex(t *testing.T) {
 func TestKrewUninstall_CannotUseIndexSyntax(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex()
 	out, err := test.Krew("uninstall", "foo/"+validPlugin).Run()
@@ -79,8 +76,7 @@ func TestKrewUninstall_CannotUseIndexSyntax(t *testing.T) {
 func TestKrewRemove_AliasSupported(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().Krew("install", validPlugin).RunOrFailOutput()
 	test.Krew("remove", validPlugin).RunOrFailOutput()
@@ -90,8 +86,7 @@ func TestKrewRemove_AliasSupported(t *testing.T) {
 func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex()
 	manifestDir := environment.NewPaths(test.Root()).IndexPluginsPath(constants.DefaultIndexName)
@@ -108,8 +103,7 @@ func TestKrewRemove_ManifestRemovedFromIndex(t *testing.T) {
 
 func TestKrewRemove_Unsafe(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	test.WithDefaultIndex()
 	test.Krew("install", validPlugin).RunOrFailOutput()
 

--- a/integration_test/update_test.go
+++ b/integration_test/update_test.go
@@ -30,8 +30,7 @@ import (
 func TestKrewUpdate(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	// nb do not call WithDefaultIndex() here
 	updateOut := string(test.Krew("update").RunOrFailOutput())
@@ -51,8 +50,7 @@ func TestKrewUpdate(t *testing.T) {
 
 func TestKrewUpdateMultipleIndexes(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 
@@ -72,8 +70,7 @@ func TestKrewUpdateMultipleIndexes(t *testing.T) {
 
 func TestKrewUpdateFailedIndex(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex()
 
@@ -91,8 +88,7 @@ func TestKrewUpdateFailedIndex(t *testing.T) {
 
 func TestKrewUpdateListsNewPlugins(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test = test.WithDefaultIndex()
 
@@ -113,8 +109,7 @@ func TestKrewUpdateListsNewPlugins(t *testing.T) {
 func TestKrewUpdateListsUpgradesAvailable(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	test = test.WithDefaultIndex()
 
 	// set version of some manifests to v0.0.0

--- a/integration_test/upgrade_test.go
+++ b/integration_test/upgrade_test.go
@@ -30,16 +30,14 @@ import (
 func TestKrewUpgrade_WithoutIndexInitialized(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	test.Krew("upgrade").RunOrFailOutput()
 }
 
 func TestKrewUpgrade(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().
 		Krew("install", "--manifest", filepath.Join("testdata", validPlugin+constants.ManifestExtension)).
@@ -61,8 +59,7 @@ func TestKrewUpgrade(t *testing.T) {
 func TestKrewUpgradePluginsFromCustomIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
@@ -84,8 +81,7 @@ func TestKrewUpgradePluginsFromCustomIndex(t *testing.T) {
 func TestKrewUpgradeSkipsManifestPlugin(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().
 		Krew("install", "--manifest", filepath.Join("testdata", validPlugin+constants.ManifestExtension)).
@@ -100,8 +96,7 @@ func TestKrewUpgradeSkipsManifestPlugin(t *testing.T) {
 func TestKrewUpgradeNoSecurityWarningForCustomIndex(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().WithCustomIndexFromDefault("foo")
 	test.Krew("install", "foo/"+validPlugin).RunOrFail()
@@ -117,8 +112,7 @@ func TestKrewUpgradeNoSecurityWarningForCustomIndex(t *testing.T) {
 func TestKrewUpgrade_CannotUseIndexSyntax(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	b, err := test.Krew("upgrade", "foo/"+validPlugin).Run()
 	if err == nil {
@@ -131,8 +125,7 @@ func TestKrewUpgrade_CannotUseIndexSyntax(t *testing.T) {
 
 func TestKrewUpgradeUnsafe(t *testing.T) {
 	skipShort(t)
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 	test.WithDefaultIndex()
 
 	cases := []string{
@@ -157,8 +150,7 @@ func TestKrewUpgradeUnsafe(t *testing.T) {
 func TestKrewUpgradeWhenPlatformNoLongerMatches(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().
 		Krew("install", validPlugin).
@@ -182,8 +174,7 @@ func TestKrewUpgradeWhenPlatformNoLongerMatches(t *testing.T) {
 func TestKrewUpgrade_ValidPluginInstalledFromManifest(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	test.WithDefaultIndex().
 		Krew("install", validPlugin).

--- a/integration_test/version_test.go
+++ b/integration_test/version_test.go
@@ -24,8 +24,7 @@ import (
 func TestKrewVersion(t *testing.T) {
 	skipShort(t)
 
-	test, cleanup := NewTest(t)
-	defer cleanup()
+	test := NewTest(t)
 
 	stdOut := string(test.Krew("version").RunOrFailOutput())
 

--- a/internal/download/downloader_test.go
+++ b/internal/download/downloader_test.go
@@ -63,8 +63,7 @@ func Test_extractZIP(t *testing.T) {
 	for _, tt := range tests {
 		// Zip has just one file named 'foo'
 		zipSrc := filepath.Join(testdataPath(), tt.in)
-		tmpDir, cleanup := testutil.NewTempDir(t)
-		defer cleanup()
+		tmpDir := testutil.NewTempDir(t)
 
 		zipReader, err := os.Open(zipSrc)
 		if err != nil {
@@ -110,8 +109,7 @@ func Test_extractTARGZ(t *testing.T) {
 
 	for _, tt := range tests {
 		tarSrc := filepath.Join(testdataPath(), tt.in)
-		tmpDir, cleanup := testutil.NewTempDir(t)
-		defer cleanup()
+		tmpDir := testutil.NewTempDir(t)
 
 		tf, err := os.Open(tarSrc)
 		if err != nil {
@@ -192,8 +190,7 @@ func TestDownloader_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			d := NewDownloader(tt.fields.verifier, tt.fields.fetcher)
 			if err := d.Get(tt.uri, tmpDir.Root()); (err != nil) != tt.wantErr {
@@ -541,8 +538,7 @@ func Test_extractMaliciousArchive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("tar.gz  "+tt.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			// do not use filepath.Join here, because it calls filepath.Clean on the result
 			reader, err := tarGZArchiveForTesting(map[string]string{tt.path: testContent})
@@ -561,8 +557,7 @@ func Test_extractMaliciousArchive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("zip  "+tt.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			// do not use filepath.Join here, because it calls filepath.Clean on the result
 			reader, err := zipArchiveReaderForTesting(map[string]string{tt.path: testContent})

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -81,8 +81,7 @@ func TestPaths(t *testing.T) {
 }
 
 func TestRealpath(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	// create regular file
 	tmpDir.Write("regular-file", nil)

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestListIndexes(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	wantIndexes := []Index{
 		{
@@ -56,8 +55,7 @@ func TestListIndexes(t *testing.T) {
 }
 
 func TestAddIndexSuccess(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	indexName := "foo"
 	localRepo := tmpDir.Path("local/" + indexName)
@@ -83,8 +81,7 @@ func TestAddIndexSuccess(t *testing.T) {
 }
 
 func TestAddIndexFailure(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	indexName := "foo"
 	paths := environment.NewPaths(tmpDir.Root())
@@ -113,8 +110,7 @@ func TestDeleteIndex(t *testing.T) {
 		t.Fatalf("not ENOENT error: %v", err)
 	}
 
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 	p := environment.NewPaths(tmpDir.Root())
 
 	// index does not exist

--- a/internal/index/indexscanner/scanner_test.go
+++ b/internal/index/indexscanner/scanner_test.go
@@ -133,8 +133,7 @@ func TestReadReceiptFromFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			plugin := "plugin" + constants.ManifestExtension
 			testReceipt := testutil.NewReceipt().WithPlugin(testutil.NewPlugin().V()).WithStatus(tt.args.status).V()

--- a/internal/indexmigration/migration_test.go
+++ b/internal/indexmigration/migration_test.go
@@ -42,8 +42,7 @@ func TestIsMigrated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			err := os.MkdirAll(tmpDir.Path(test.dirPath), os.ModePerm)
 			if err != nil {
@@ -63,8 +62,7 @@ func TestIsMigrated(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	tmpDir.Write("index/.git", nil)
 

--- a/internal/installation/install_test.go
+++ b/internal/installation/install_test.go
@@ -106,8 +106,7 @@ func Test_createOrUpdateLink(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			if err := createOrUpdateLink(tmpDir.Root(), tt.binary, tt.pluginName); (err != nil) != tt.wantErr {
 				t.Errorf("createOrUpdateLink() error = %v, wantErr %v", err, tt.wantErr)
@@ -143,8 +142,7 @@ func Test_removeLink_notExists(t *testing.T) {
 }
 
 func TestUninstall_cantUninstallItself(t *testing.T) {
-	tempDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tempDir := testutil.NewTempDir(t)
 	envPath := environment.NewPaths(tempDir.Root())
 	expectedErrorMessagePart := "not allowed"
 	if err := Uninstall(envPath, "krew"); !strings.Contains(err.Error(), expectedErrorMessagePart) {
@@ -154,8 +152,7 @@ func TestUninstall_cantUninstallItself(t *testing.T) {
 }
 
 func Test_removeLink_linkExists(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	link := filepath.Join(tmpDir.Root(), "some-symlink")
 	if err := os.Symlink(os.TempDir(), link); err != nil {
@@ -168,8 +165,7 @@ func Test_removeLink_linkExists(t *testing.T) {
 }
 
 func Test_removeLink_fails(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	// create an unreadable directory and trigger "permission denied" error
 	unreadableDir := filepath.Join(tmpDir.Root(), "unreadable")
@@ -220,8 +216,7 @@ func TestIsWindows_envOverride(t *testing.T) {
 }
 
 func Test_downloadAndExtract(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	// start a local http server to serve the test archive from pkg/download/testdata
 	testdataDir := filepath.Join(testdataPath(t), "..", "..", "download", "testdata")
@@ -244,8 +239,7 @@ func Test_downloadAndExtract(t *testing.T) {
 }
 
 func Test_downloadAndExtract_fileOverride(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	testFile := filepath.Join(testdataPath(t), "..", "..", "download", "testdata", "test-without-directory.tar.gz")
 	checksum := "433b9e0b6cb9f064548f451150799daadcc70a3496953490c5148c8e550d2f4e"
@@ -301,8 +295,7 @@ func Test_applyDefaults(t *testing.T) {
 }
 
 func TestCleanupStaleKrewInstallations(t *testing.T) {
-	dir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	dir := testutil.NewTempDir(t)
 
 	testFiles := []string{
 		"dir1/f1.txt",

--- a/internal/installation/move_test.go
+++ b/internal/installation/move_test.go
@@ -186,13 +186,11 @@ func Test_getDirectMove(t *testing.T) {
 }
 
 func Test_moveOrCopyDir_canMoveToNonExistingDir(t *testing.T) {
-	srcDir, cleanupSrc := testutil.NewTempDir(t)
-	defer cleanupSrc()
+	srcDir := testutil.NewTempDir(t)
 
 	srcDir.Write("some-file", nil)
 
-	dstDir, cleanupDst := testutil.NewTempDir(t)
-	defer cleanupDst()
+	dstDir := testutil.NewTempDir(t)
 
 	dst := dstDir.Path("non-existing-dir")
 
@@ -213,13 +211,11 @@ func Test_moveOrCopyDir_canMoveToNonExistingDir(t *testing.T) {
 }
 
 func Test_moveOrCopyDir_removesExistingTarget(t *testing.T) {
-	srcDir, cleanupSrc := testutil.NewTempDir(t)
-	defer cleanupSrc()
+	srcDir := testutil.NewTempDir(t)
 
 	srcDir.Write("some-file", nil)
 
-	dstDir, cleanupDst := testutil.NewTempDir(t)
-	defer cleanupDst()
+	dstDir := testutil.NewTempDir(t)
 
 	for i := 0; i < 3; i++ { // write some files
 		dstDir.Write(fmt.Sprintf("file-%d", i), nil)

--- a/internal/installation/receipt/receipt_test.go
+++ b/internal/installation/receipt/receipt_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	testPlugin := testutil.NewPlugin().WithName("some-plugin").WithPlatforms(testutil.NewPlatform().V()).V()
 	testReceipt := testutil.NewReceipt().WithPlugin(testPlugin).V()
@@ -48,8 +47,7 @@ func TestStore(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
-	tmpDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tmpDir := testutil.NewTempDir(t)
 
 	testPlugin := testutil.NewPlugin().WithName("foo").WithPlatforms(testutil.NewPlatform().V()).V()
 	testPluginReceipt := testutil.NewReceipt().WithPlugin(testPlugin).V()

--- a/internal/installation/util_test.go
+++ b/internal/installation/util_test.go
@@ -56,8 +56,7 @@ func TestGetInstalledPluginReceipts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tempDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tempDir := testutil.NewTempDir(t)
 
 			for _, plugin := range test.receipts {
 				tempDir.WriteYAML(plugin.Name+constants.ManifestExtension, plugin)
@@ -75,8 +74,7 @@ func TestGetInstalledPluginReceipts(t *testing.T) {
 }
 
 func TestInstalledPluginsFromIndex(t *testing.T) {
-	tempDir, cleanup := testutil.NewTempDir(t)
-	defer cleanup()
+	tempDir := testutil.NewTempDir(t)
 
 	indexA := index.ReceiptStatus{Source: index.SourceIndex{Name: "a"}}
 	var indexNone index.ReceiptStatus

--- a/internal/receiptsmigration/migration_test.go
+++ b/internal/receiptsmigration/migration_test.go
@@ -52,8 +52,7 @@ func TestIsMigrated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
+			tmpDir := testutil.NewTempDir(t)
 
 			newPaths := environment.NewPaths(tmpDir.Root())
 

--- a/internal/testutil/tempdir.go
+++ b/internal/testutil/tempdir.go
@@ -34,20 +34,19 @@ type TempDir struct {
 
 // NewTempDir creates a temporary directory and a cleanup function.
 // It is the responsibility of calling code to call cleanup when done.
-func NewTempDir(t *testing.T) (tmpDir *TempDir, cleanup func()) {
+func NewTempDir(t *testing.T) *TempDir {
 	t.Helper()
 	root, err := ioutil.TempDir("", "krew-test")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	tmpDir = &TempDir{t: t, root: root}
-
-	return tmpDir, func() {
+	t.Cleanup(func() {
 		if err := os.RemoveAll(root); err != nil {
 			t.Logf("warning: failed to remove tempdir %s: %+v", root, err)
 		}
-	}
+	})
+
+	return &TempDir{t: t, root: root}
 }
 
 // Root returns the root of the temporary directory.

--- a/internal/testutil/tempdir.go
+++ b/internal/testutil/tempdir.go
@@ -32,8 +32,8 @@ type TempDir struct {
 	root string
 }
 
-// NewTempDir creates a temporary directory and a cleanup function.
-// It is the responsibility of calling code to call cleanup when done.
+// NewTempDir creates a temporary directory which is automatically cleaned up
+// when the test exits.
 func NewTempDir(t *testing.T) *TempDir {
 	t.Helper()
 	root, err := ioutil.TempDir("", "krew-test")


### PR DESCRIPTION
Go 1.14 comes with a `t.Cleanup()` method to register callbacks to be executed when the test is done (see https://golang.org/doc/go1.14#testing). This PR switches to this pattern.