### PR TITLE
tweak uninstall cmd message

### DIFF
--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -48,7 +48,7 @@ Remarks:
 			if err := installation.Uninstall(paths, name); err != nil {
 				return errors.Wrapf(err, "failed to uninstall plugin %s", name)
 			}
-			fmt.Fprintf(os.Stderr, "Uninstalled plugin %s\n", name)
+			fmt.Fprintf(os.Stderr, "Uninstalled plugin: %s\n", name)
 		}
 		return nil
 	},


### PR DESCRIPTION
Uninstall messages can look odd with custom indexes allowing
generic names:

    Uninstalled plugin use
    Uninstalled plugin build

So using a colon to separate it out like the "install" cmd.