### PR TITLE
Support arm architecture install

### DIFF
--- a/site/content/docs/user-guide/setup/install.md
+++ b/site/content/docs/user-guide/setup/install.md
@@ -24,7 +24,7 @@ Krew self-hosts).
       set -x; cd "$(mktemp -d)" &&
       curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz" &&
       tar zxvf krew.tar.gz &&
-      KREW=./krew-"$(uname | tr '[:upper:]' '[:lower:]')_amd64" &&
+      KREW=./krew-"$(uname | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm.*$/arm/')" &&
       "$KREW" install krew
     )
     ```
@@ -50,7 +50,7 @@ Krew self-hosts).
       set -x; set temp_dir (mktemp -d); cd "$temp_dir" &&
       curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz" &&
       tar zxvf krew.tar.gz &&
-      set KREWNAME krew-(uname | tr '[:upper:]' '[:lower:]')_amd64 &&
+      set KREWNAME krew-(uname | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm.*$/arm/') &&
       ./$KREWNAME install krew &&
       set -e KREWNAME; set -e temp_dir
     end


### PR DESCRIPTION
Detect architecture with `uname -m` and use amd64 or arm to extract the binaries depending on the current system architecture.
