### PR TITLE
Fixed use of fish shell evaluation with (...) instead of bash style $(…)

### DIFF
--- a/site/content/docs/user-guide/setup/install.md
+++ b/site/content/docs/user-guide/setup/install.md
@@ -50,7 +50,7 @@ Krew self-hosts).
       set -x; set temp_dir (mktemp -d); cd "$temp_dir" &&
       curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz" &&
       tar zxvf krew.tar.gz &&
-      set KREWNAME krew-(uname | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm.*$/arm/') &&
+      set KREWNAME krew-(uname | tr '[:upper:]' '[:lower:]')_(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm.*$/arm/') &&
       ./$KREWNAME install krew &&
       set -e KREWNAME; set -e temp_dir
     end


### PR DESCRIPTION
Fixed use of fish shell evaluation with (...) instead of bash style $(…) in installation script in the specific fish section.

Tested and working well.


