### PR TITLE
Fix : sanitize PATH dir

### DIFF
--- a/cmd/krew/cmd/internal/setup_check.go
+++ b/cmd/krew/cmd/internal/setup_check.go
@@ -58,7 +58,12 @@ func IsBinDirInPATH(paths environment.Paths) bool {
 
 	binPath := paths.BinPath()
 	for _, dirInPATH := range filepath.SplitList(os.Getenv("PATH")) {
-		if dirInPATH == binPath {
+		normalizedDirInPATH, err := filepath.Abs(dirInPATH)
+		if err != nil {
+			klog.Warningf("Cannot get absolute path: %v, %v", normalizedDirInPATH, err)
+			continue
+		}
+		if normalizedDirInPATH == binPath {
 			return true
 		}
 	}


### PR DESCRIPTION
Actually comparison between .krew/bin directory and path segment directory
is done with equal operator. This PR allow method filepath. Abs to be call during krew path creation
`/internal/environment/environment.go#L43` and also in `/cmd/krew/cmd/internal/setup_check.go#L62` path directory iteration

Fixes #664 
