### PR TITLE
Default index function

### DIFF
--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -142,8 +142,9 @@ func ensureDefaultIndexIfNoneExist() error {
 	}
 
 	klog.V(3).Infof("No index found, add default index.")
-	fmt.Fprintf(os.Stderr, "Adding \"default\" plugin index from %s.\n", index.DefaultIndex())
-	return errors.Wrap(indexoperations.AddIndex(paths, constants.DefaultIndexName, index.DefaultIndex()),
+	defaultIndex := index.DefaultIndex()
+	fmt.Fprintf(os.Stderr, "Adding \"default\" plugin index from %s.\n", defaultIndex)
+	return errors.Wrap(indexoperations.AddIndex(paths, constants.DefaultIndexName, defaultIndex),
 		"failed to add default plugin index in absence of no indexes")
 }
 

--- a/cmd/krew/cmd/update.go
+++ b/cmd/krew/cmd/update.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/krew/internal/index/indexscanner"
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/pkg/constants"
+	"sigs.k8s.io/krew/pkg/index"
 )
 
 // updateCmd represents the update command
@@ -141,8 +142,8 @@ func ensureDefaultIndexIfNoneExist() error {
 	}
 
 	klog.V(3).Infof("No index found, add default index.")
-	fmt.Fprintf(os.Stderr, "Adding \"default\" plugin index from %s.\n", constants.DefaultIndexURI)
-	return errors.Wrap(indexoperations.AddIndex(paths, constants.DefaultIndexName, constants.DefaultIndexURI),
+	fmt.Fprintf(os.Stderr, "Adding \"default\" plugin index from %s.\n", index.DefaultIndex())
+	return errors.Wrap(indexoperations.AddIndex(paths, constants.DefaultIndexName, index.DefaultIndex()),
 		"failed to add default plugin index in absence of no indexes")
 }
 

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/krew/internal/installation"
 	"sigs.k8s.io/krew/internal/version"
 	"sigs.k8s.io/krew/pkg/constants"
+	"sigs.k8s.io/krew/pkg/index"
 )
 
 // versionCmd represents the version command
@@ -42,7 +43,7 @@ Remarks:
 		conf := [][]string{
 			{"GitTag", version.GitTag()},
 			{"GitCommit", version.GitCommit()},
-			{"IndexURI", constants.DefaultIndexURI},
+			{"IndexURI", index.DefaultIndex()},
 			{"BasePath", paths.BasePath()},
 			{"IndexPath", paths.IndexPath(constants.DefaultIndexName)},
 			{"InstallPath", paths.InstallPath()},

--- a/pkg/index/util.go
+++ b/pkg/index/util.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Kubernetes Authors.
+// Copyright 2020 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/index/util.go
+++ b/pkg/index/util.go
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package constants
+package index
 
-const (
-	CurrentAPIVersion = "krew.googlecontainertools.github.com/v1alpha2"
-	PluginKind        = "Plugin"
-	ManifestExtension = ".yaml"
-	KrewPluginName    = "krew" // plugin name of krew itself
+import (
+	"os"
 
-	// DefaultIndexURI points to the upstream index.
-	DefaultIndexURI = "https://github.com/kubernetes-sigs/krew-index.git"
-	// DefaultIndexName is a magic string that's used for a plugin name specified without an index.
-	DefaultIndexName = "default"
+	"sigs.k8s.io/krew/pkg/constants"
 )
+
+func DefaultIndex() string {
+	if uri := os.Getenv("KREW_DEFAULT_INDEX_URI"); uri != "" {
+		return uri
+	}
+	return constants.DefaultIndexURI
+}

--- a/pkg/index/util_test.go
+++ b/pkg/index/util_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestDefaultIndex(t *testing.T) {
 	if got := DefaultIndex(); got != constants.DefaultIndexURI {
-		t.Errorf("expected DefaultIndex() to be %q; got=%q", constants.DefaultIndexURI, got)
+		t.Errorf("DefaultIndex() = %q, want %q", got, constants.DefaultIndexURI)
 	}
 
 	want := "foo"
@@ -31,6 +31,6 @@ func TestDefaultIndex(t *testing.T) {
 	defer os.Unsetenv("KREW_DEFAULT_INDEX_URI")
 
 	if got := DefaultIndex(); got != want {
-		t.Errorf("expected DefaultIndex() to be %q; got=%q", want, got)
+		t.Errorf("DefaultIndex() = %q, want %q", got, want)
 	}
 }

--- a/pkg/index/util_test.go
+++ b/pkg/index/util_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/krew/pkg/constants"
+)
+
+func TestDefaultIndex(t *testing.T) {
+	if got := DefaultIndex(); got != constants.DefaultIndexURI {
+		t.Errorf("expected DefaultIndex() to be %q; got=%q", constants.DefaultIndexURI, got)
+	}
+
+	want := "foo"
+	os.Setenv("KREW_DEFAULT_INDEX_URI", want)
+	defer os.Unsetenv("KREW_DEFAULT_INDEX_URI")
+
+	if got := DefaultIndex(); got != want {
+		t.Errorf("expected DefaultIndex() to be %q; got=%q", want, got)
+	}
+}


### PR DESCRIPTION
Adding this based on the comment here https://github.com/kubernetes-sigs/krew/pull/666#discussion_r528472892. This reverts back `constants.go` so that it only has the constant values and adds a `pkg/index/util.go` that has the `DefaultIndex` function in it.

/assign @ahmetb 
/assign @corneliusweig 

Related issue: #637 
<!-- For proposed features, make sure there's an issue it's discussed first -->
