### PR TITLE
Update golanci-lint to v1.33.0 and enable govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,8 @@ linters:
     - goimports
     - golint
     - gosimple
+    - govet
+    - ineffassign
     - interfacer
     - maligned
     - misspell

--- a/cmd/krew/cmd/install_test.go
+++ b/cmd/krew/cmd/install_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Test_readPluginFromURL(t *testing.T) {
-	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join("../../../integration_test/testdata"))))
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.FromSlash("../../../integration_test/testdata"))))
 	defer server.Close()
 
 	tests := []struct {

--- a/cmd/krew/cmd/internal/setup_check_test.go
+++ b/cmd/krew/cmd/internal/setup_check_test.go
@@ -77,7 +77,7 @@ func TestIsBinDirInPATH_NonNormalized(t *testing.T) {
 func TestSetupInstructions_windows(t *testing.T) {
 	const instructionsContain = `USERPROFILE`
 	os.Setenv("KREW_OS", "windows")
-	defer func() { os.Unsetenv("KREW_OS") }()
+	defer os.Unsetenv("KREW_OS")
 	instructions := SetupInstructions()
 	if !strings.Contains(instructions, instructionsContain) {
 		t.Errorf("expected %q\nto contain %q", instructions, instructionsContain)

--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -23,7 +23,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
   echo >&2 'Installing golangci-lint'
   curl --silent --fail --location \
-    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.27.0
+    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.33.0
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
See list of currently active linters by running

```
golangci-lint linters
```

/assign @chriskim06 
Fixes #639