### PR TITLE
Fix rights of the installDir

### DIFF
--- a/internal/installation/move.go
+++ b/internal/installation/move.go
@@ -178,6 +178,10 @@ func moveToInstallDir(srcDir, installDir string, fos []index.FileOperation) erro
 		}()
 		return errors.Wrapf(err, "could not rename/copy directory %q to %q", tmp, installDir)
 	}
+
+	if err = os.Chmod(installDir, 0755); err != nil {
+		return errors.Wrapf(err, "could not change rights on directory %q", installDir)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Before this fix the installDir have the default mode of the ioutil.Tempdir function which is 0700.
If krew is install globally for multi users, they can't access the krew plugins.
This fix force the 0755 mode on the installDir.
