### PR TITLE
Changes install doc to remove question of path authority

### DIFF
--- a/site/content/docs/user-guide/setup/install.md
+++ b/site/content/docs/user-guide/setup/install.md
@@ -33,7 +33,7 @@ Krew self-hosts).
    this, update your `.bashrc` or `.zshrc` file and append the following line:
 
      ```sh
-     export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+     export PATH="$PATH:${KREW_ROOT:-$HOME/.krew}/bin"
      ```
 
    and restart your shell.


### PR DESCRIPTION
As the linux path prefers running what shows up first in the path, there is a potential for someone to create a script in .krew/bin to override another non-krew binary or script from anywhere in the system, even /bin. This puts krew at the end of the path to remove that potential and improve overall security.

Fixes #676