### PR TITLE
Add myself to owners alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,6 @@
 aliases:
   krew-maintainers:
     - ahmetb
+    - chriskim06
     - corneliusweig
     - soltysh


### PR DESCRIPTION
Based on the steps outlined here https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process I think I need to be added to the OWNERS_ALIASES file
> Only people listed in the relevant OWNERS files, either directly or through an alias, as described above, can act as approvers, including the individual who opened the PR.
