### PR TITLE
Support LICENSES filename in manifest validation

### DIFF
--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -166,11 +166,14 @@ func installPlatformSpec(manifestFile string, p index.Platform) error {
 }
 
 var licenseFiles = map[string]struct{}{
-	"license":     {},
-	"license.txt": {},
-	"license.md":  {},
-	"copying":     {},
-	"copying.txt": {},
+	"license":      {},
+	"license.txt":  {},
+	"license.md":   {},
+	"licenses":     {},
+	"licenses.txt": {},
+	"licenses.md":  {},
+	"copying":      {},
+	"copying.txt":  {},
 }
 
 func validateLicenseFileExists(krewRoot string) error {


### PR DESCRIPTION
Some plugins like https://github.com/jetstack/cert-manager store the license information in a file called LICENSES. This adds support for this filename to the manifest validation.

Fixes #691