### PR TITLE
hack: drop impi in favor of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - gci
     - gocritic
     - gofmt
     - goimports

--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -29,13 +29,6 @@ fi
 # configured by .golangci.yml
 "$gopath/bin/golangci-lint" run
 
-if ! [[ -x "${gopath}/bin/impi" ]]; then
-  echo >&2 'Installing impi'
-  go install github.com/pavius/impi/cmd/impi@c1cbdcb
-fi
-
-"$gopath/bin/impi" --local sigs.k8s.io/krew --scheme stdThirdPartyLocal ./...
-
 # install shfmt that ensures consistent format in shell scripts
 if ! [[ -x "${gopath}/bin/shfmt" ]]; then
   echo >&2 'Installing shfmt'


### PR DESCRIPTION
Since golangci-lint brought that functionality, use it instead of another dependency.
