### PR TITLE
Release separated archives for each platform (#697)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: out/krew.*
+        file: out/krew*
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true

--- a/docs/RELEASING_KREW.md
+++ b/docs/RELEASING_KREW.md
@@ -13,12 +13,10 @@
     ```sh
     krew=out/bin/krew-darwin_amd64 # assuming macOS amd64
 
-    KREW_ROOT="$(mktemp -d --tmpdir krew-XXXXXXXXXX)" KREW_OS=darwin \
-        $krew install --manifest=out/krew.yaml --archive=out/krew.tar.gz && \
-    KREW_ROOT="$(mktemp -d --tmpdir krew-XXXXXXXXXX)" KREW_OS=linux \
-        $krew install --manifest=out/krew.yaml --archive=out/krew.tar.gz && \
-    KREW_ROOT="$(mktemp -d --tmpdir krew-XXXXXXXXXX)" KREW_OS=windows \
-        $krew install --manifest=out/krew.yaml --archive=out/krew.tar.gz
+    for osarch in darwin_amd64 darwin_arm64 linux_amd64 linux_arm linux_arm64 windows_amd64; do
+      KREW_ROOT="$(mktemp -d --tmpdir krew-XXXXXXXXXX)" KREW_OS="${osarch%_*}" KREW_ARCH="${osarch#*_}" \
+          $krew install --manifest=out/krew.yaml --archive="out/krew-${osarch}.tar.gz"
+    done
     ```
 
 ### Release a new version

--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -26,8 +26,8 @@ spec:
       https://krew.sigs.k8s.io/docs/user-guide/quickstart/.
 
   platforms:
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
-    sha256: KREW_TAR_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew-darwin_amd64.tar.gz
+    sha256: KREW_DARWIN_AMD64_CHECKSUM
     bin: krew
     files:
     - from: ./krew-darwin_amd64
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
-    sha256: KREW_TAR_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew-darwin_arm64.tar.gz
+    sha256: KREW_DARWIN_ARM64_CHECKSUM
     bin: krew
     files:
     - from: ./krew-darwin_arm64
@@ -50,8 +50,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
-    sha256: KREW_TAR_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew-linux_amd64.tar.gz
+    sha256: KREW_LINUX_AMD64_CHECKSUM
     bin: krew
     files:
     - from: ./krew-linux_amd64
@@ -62,8 +62,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
-    sha256: KREW_TAR_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew-linux_arm.tar.gz
+    sha256: KREW_LINUX_ARM_CHECKSUM
     bin: krew
     files:
     - from: ./krew-linux_arm
@@ -74,8 +74,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
-    sha256: KREW_TAR_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew-linux_arm64.tar.gz
+    sha256: KREW_LINUX_ARM64_CHECKSUM
     bin: krew
     files:
     - from: ./krew-linux_arm64
@@ -86,8 +86,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew.tar.gz
-    sha256: KREW_TAR_CHECKSUM
+  - uri: https://github.com/kubernetes-sigs/krew/releases/download/KREW_TAG/krew-windows_amd64.tar.gz
+    sha256: KREW_WINDOWS_AMD64_CHECKSUM
     bin: krew.exe
     files:
     - from: ./krew-windows_amd64.exe

--- a/hack/verify-installation.sh
+++ b/hack/verify-installation.sh
@@ -33,7 +33,7 @@ if [[ ! -f "${krew_manifest}" ]]; then
   exit 1
 fi
 
-krew_archive="${build_dir}/krew.tar.gz"
+krew_archive="${build_dir}/krew-${goos}_${goarch}.tar.gz"
 if [[ ! -f "${krew_archive}" ]]; then
   echo >&2 "Could not find archive ${krew_archive}."
   echo >&2 "Did you run hack/make-all.sh?"


### PR DESCRIPTION
Fixes #697 

In install instructions, use `--archive` (and therefore `--manifest-url`) to not download again the tarball when launching `krew install` command.