### PR TITLE
ISSUE-696: Explore use of t.TempDir()

### DIFF
--- a/internal/testutil/tempdir.go
+++ b/internal/testutil/tempdir.go
@@ -36,15 +36,7 @@ type TempDir struct {
 // when the test exits.
 func NewTempDir(t *testing.T) *TempDir {
 	t.Helper()
-	root, err := ioutil.TempDir("", "krew-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(root); err != nil {
-			t.Logf("warning: failed to remove tempdir %s: %+v", root, err)
-		}
-	})
+	root := t.TempDir()
 
 	return &TempDir{t: t, root: root}
 }


### PR DESCRIPTION
**PR Summary:**
- Fixes #696

**For the reviewers:** 
I'm not sure this is the right implementation, as @ahmetb asked to _deprecate_ the implementation of `testutil.NewTempDir(t)` should I add some `deprecation notice`? Thanks in advance for the advices/reviews. 
