### PR TITLE
Clarify the role of the plugin name

### DIFF
--- a/site/content/docs/developer-guide/plugin-manifest.md
+++ b/site/content/docs/developer-guide/plugin-manifest.md
@@ -25,7 +25,8 @@ only Linux and macOS:
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  # 'name' must match the filename of the manifest.
+  # 'name' must match the filename of the manifest. The name defines how
+  # the plugin is invoked, for example: `kubectl restart`
   name: restart
 spec:
   # 'version' is a valid semantic version string (see semver.org)


### PR DESCRIPTION
This is a follow-up to https://github.com/kubernetes-sigs/krew-index/pull/1157. Apparently, it was not sufficiently clear that the plugin name determines how a plugin is invoked.

Related issue: https://github.com/kubernetes-sigs/krew-index/pull/1157
/assign @chriskim06 