### PR TITLE
Clearly state the operating system and architecture in the search result

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -106,7 +107,7 @@ Examples:
 			} else if ok {
 				status = "no"
 			} else {
-				status = "unavailable on " + runtime.GOOS
+				status =  fmt.Sprintf("unavailable on %v/%v", runtime.GOOS, runtime.GOARCH)
 			}
 
 			rows = append(rows, []string{displayName(v.p, v.indexName), limitString(v.p.Spec.ShortDescription, 50), status})

--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -107,7 +107,7 @@ Examples:
 			} else if ok {
 				status = "no"
 			} else {
-				status =  fmt.Sprintf("unavailable on %v/%v", runtime.GOOS, runtime.GOARCH)
+				status = fmt.Sprintf("unavailable on %v/%v", runtime.GOOS, runtime.GOARCH)
 			}
 
 			rows = append(rows, []string{displayName(v.p, v.indexName), limitString(v.p.Spec.ShortDescription, 50), status})


### PR DESCRIPTION
Searching images with krew on linux/arm64:

~~~plaintext
$ kubectl krew search images
NAME    DESCRIPTION                                 INSTALLED
images  Show container images used in the cluster.  unavailable on Linux
~~~

In fact, it just lacks support for linux/arm64.