### PR TITLE
fix the loading row remains even after the plugins are loaded

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -88,7 +88,7 @@
             const plugins = json.data?.plugins;
             
             while (pluginTableElem.firstChild) {
-                pluginTableElem.removeChild(pluginTableElem.firstElementChild);
+                pluginTableElem.removeChild(pluginTableElem.firstChild);
             }
             
             if (!Boolean(plugins?.length)) {


### PR DESCRIPTION
Fixes #729 site: plugin list "Loading"... row never disappears

remove table tr element which shows "Loading..." before render plugin list table. 