### PR TITLE
Correct windows krew install command.

### DIFF
--- a/site/content/docs/user-guide/setup/install.md
+++ b/site/content/docs/user-guide/setup/install.md
@@ -79,7 +79,7 @@ Krew self-hosts).
 1. Run the following command to install krew:
 
     ```sh
-    krew install krew
+    .\krew install krew
     ```
 
 1. Add the `%USERPROFILE%\.krew\bin` directory to your `PATH` environment variable


### PR DESCRIPTION
Running with PowerShell confuses a few users that we direct to install krew, as they come across this error
```
The command krew was not found, but does exist in the current location. Windows PowerShell does not load commands from the current location by default. If you trust this command, instead type: ".\krew". See "get-help about_Command_Precedence" for more details.
```
Suggest changing to `.\krew install krew` to avoid that
