### PR TITLE
feat: skip install on validate-krew-manifest

### DIFF
--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -39,9 +39,11 @@ import (
 )
 
 var flManifest string
+var flInstall bool
 
 func init() {
 	flag.StringVar(&flManifest, "manifest", "", "path to plugin manifest file")
+	flag.BoolVar(&flInstall, "install", true, "install the plugin as part of the validation")
 }
 
 func main() {
@@ -97,15 +99,17 @@ func validateManifestFile(path string) error {
 	}
 	klog.Infof("no overlapping spec.platform[].selector")
 
-	// exercise "install" for all platforms
-	for i, p := range p.Spec.Platforms {
-		klog.Infof("installing spec.platform[%d]", i)
-		if err := installPlatformSpec(path, p); err != nil {
-			return errors.Wrapf(err, "spec.platforms[%d] failed to install", i)
+	if flInstall {
+		// exercise "install" for all platforms
+		for i, p := range p.Spec.Platforms {
+			klog.Infof("installing spec.platform[%d]", i)
+			if err := installPlatformSpec(path, p); err != nil {
+				return errors.Wrapf(err, "spec.platforms[%d] failed to install", i)
+			}
+			klog.Infof("installed  spec.platforms[%d]", i)
 		}
-		klog.Infof("installed  spec.platforms[%d]", i)
+		log.Printf("all %d spec.platforms installed fine", len(p.Spec.Platforms))
 	}
-	log.Printf("all %d spec.platforms installed fine", len(p.Spec.Platforms))
 	return nil
 }
 

--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -39,11 +39,11 @@ import (
 )
 
 var flManifest string
-var flInstall bool
+var flSkipInstall bool
 
 func init() {
 	flag.StringVar(&flManifest, "manifest", "", "path to plugin manifest file")
-	flag.BoolVar(&flInstall, "install", true, "install the plugin as part of the validation")
+	flag.BoolVar(&flSkipInstall, "skip-install", false, "skips installing the plugin as part of the validation")
 }
 
 func main() {
@@ -99,7 +99,7 @@ func validateManifestFile(path string) error {
 	}
 	klog.Infof("no overlapping spec.platform[].selector")
 
-	if flInstall {
+	if !flSkipInstall {
 		// exercise "install" for all platforms
 		for i, p := range p.Spec.Platforms {
 			klog.Infof("installing spec.platform[%d]", i)


### PR DESCRIPTION
I'm working in [integrating the generation of krew manifests into GoReleaser](https://github.com/goreleaser/goreleaser/pull/2639), and one thing I would like to do there is a test to validate that test-generated manifests are valid... 

But, while testing, the URLs are all faked, so, installing them won't work.

I would still like to be able to validate everything else though, so I added a new flag which we can pass `-install=false` so it won't actually install anything...

Happy to hear your thoughts on this!

Cheers!