### PR TITLE
Prevent windows msys shell from interpreting @{upstream} arg

### DIFF
--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -80,7 +80,8 @@ func Exec(pwd string, args ...string) (string, error) {
 	klog.V(4).Infof("Going to run git %s", strings.Join(args, " "))
 	cmd := osexec.Command("git", args...)
 
-	// NOTE: https://github.com/kubernetes-sigs/krew/pull/739
+	// NOTE: on windows, msys2 and cygwin interpret args e.g. @{upstream} and therefore
+	// acts differently than git-for-windows. see #739
 	if runtime.GOOS == "windows" {
 		environ := os.Environ()
 

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -81,10 +81,10 @@ func Exec(pwd string, args ...string) (string, error) {
 	cmd := osexec.Command("git", args...)
 
 	// NOTE: on windows, msys2 and cygwin interpret args e.g. @{upstream} and therefore
-	// acts differently than git-for-windows. see #739
+	// acts differently than git-for-windows.
+	// see https://github.com/kubernetes-sigs/krew/pull/739
 	environ := os.Environ()
 	if runtime.GOOS == "windows" {
-
 		env := "MSYS=noglob"
 		if v := os.Getenv("MSYS"); v != "" {
 			env += " " + v

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -83,8 +83,9 @@ func Exec(pwd string, args ...string) (string, error) {
 	// NOTE: on windows, msys2 and cygwin interpret args e.g. @{upstream} and therefore
 	// acts differently than git-for-windows.
 	// see https://github.com/kubernetes-sigs/krew/pull/739
-	environ := os.Environ()
 	if runtime.GOOS == "windows" {
+		environ := os.Environ()
+
 		env := "MSYS=noglob"
 		if v := os.Getenv("MSYS"); v != "" {
 			env += " " + v
@@ -95,9 +96,9 @@ func Exec(pwd string, args ...string) (string, error) {
 		if v := os.Getenv("CYGWIN"); v != "" {
 			env += " " + v
 		}
-		environ = append(environ, env)
+
+		cmd.Env = append(environ, env)
 	}
-	cmd.Env = environ
 
 	cmd.Dir = pwd
 	buf := bytes.Buffer{}

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -97,7 +97,8 @@ func Exec(pwd string, args ...string) (string, error) {
 			env += " " + v
 		}
 
-		cmd.Env = append(environ, env)
+		environ = append(environ, env)
+		cmd.Env = environ
 	}
 
 	cmd.Dir = pwd

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -55,11 +55,7 @@ func updateAndCleanUntracked(destinationPath string) error {
 		return errors.Wrapf(err, "fetch index at %q failed", destinationPath)
 	}
 
-	upstream := "@{upstream}"
-	if runtime.GOOS == "windows" {
-		upstream = `@\{upstream\}`
-	}
-	if _, err := Exec(destinationPath, "reset", "--hard", upstream); err != nil {
+	if _, err := Exec(destinationPath, "reset", "--hard", "@{upstream}"); err != nil {
 		return errors.Wrapf(err, "reset index at %q failed", destinationPath)
 	}
 
@@ -83,6 +79,9 @@ func GetRemoteURL(dir string) (string, error) {
 func Exec(pwd string, args ...string) (string, error) {
 	klog.V(4).Infof("Going to run git %s", strings.Join(args, " "))
 	cmd := osexec.Command("git", args...)
+	if runtime.GOOS == "windows" {
+		cmd.Env = append(os.Environ(), "MSYS=noglob")
+	}
 	cmd.Dir = pwd
 	buf := bytes.Buffer{}
 	var w io.Writer = &buf

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -82,8 +82,8 @@ func Exec(pwd string, args ...string) (string, error) {
 
 	// NOTE: on windows, msys2 and cygwin interpret args e.g. @{upstream} and therefore
 	// acts differently than git-for-windows. see #739
+	environ := os.Environ()
 	if runtime.GOOS == "windows" {
-		environ := os.Environ()
 
 		env := "MSYS=noglob"
 		if v := os.Getenv("MSYS"); v != "" {
@@ -96,9 +96,8 @@ func Exec(pwd string, args ...string) (string, error) {
 			env += " " + v
 		}
 		environ = append(environ, env)
-
-		cmd.Env = environ
 	}
+	cmd.Env = environ
 
 	cmd.Dir = pwd
 	buf := bytes.Buffer{}

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	osexec "os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -54,7 +55,11 @@ func updateAndCleanUntracked(destinationPath string) error {
 		return errors.Wrapf(err, "fetch index at %q failed", destinationPath)
 	}
 
-	if _, err := Exec(destinationPath, "reset", "--hard", "@{upstream}"); err != nil {
+	upstream := "@{upstream}"
+	if runtime.GOOS == "windows" {
+		upstream = `@\{upstream\}`
+	}
+	if _, err := Exec(destinationPath, "reset", "--hard", upstream); err != nil {
 		return errors.Wrapf(err, "reset index at %q failed", destinationPath)
 	}
 


### PR DESCRIPTION
Fixes #737
