### PR TITLE
validate-krew-manifest: Add windows/arm64 to supported platforms

### DIFF
--- a/cmd/validate-krew-manifest/main.go
+++ b/cmd/validate-krew-manifest/main.go
@@ -237,6 +237,7 @@ func allPlatforms() []installation.OSArchPair {
 	return []installation.OSArchPair{
 		{OS: "windows", Arch: "386"},
 		{OS: "windows", Arch: "amd64"},
+		{OS: "windows", Arch: "arm64"},
 		{OS: "linux", Arch: "386"},
 		{OS: "linux", Arch: "amd64"},
 		{OS: "linux", Arch: "arm"},


### PR DESCRIPTION
This PR updates validate-krew-manifest  to add windows/arm64 to supported platforms, because Go 1.17 added support of 64-bit ARM architecture on Windows.

- https://go.dev/doc/go1.17#windows