### PR TITLE
Adding clarity for plugin repo naming

### DIFF
--- a/site/content/docs/developer-guide/develop/naming-guide.md
+++ b/site/content/docs/developer-guide/develop/naming-guide.md
@@ -67,6 +67,10 @@ Plugin names should not include "kube-" or "kubernetes-" prefixes.
 
 - **NO:** `kubectl kube-node-admin` ("kubectl " already has "kube" in it)
 - **YES:** `kubectl node-admin`
+  
+While it is not recommended to include "kube*" in the plugin command name it
+is recommended that the code repository starts with "kubectl-" so plugin
+source code can be found outside of krew and the intended use is clear.
 
 ##### _Avoid Resource Acronyms and Abbreviations_
 


### PR DESCRIPTION
I'm adding this based on convention I've seen with other plugins but if there's something else we recommend I'm fine with that too. This clarity can help plugin developers and companies looking for naming guidance and who want to avoid any trademark confusion.

Fixes #...
Related issue: #...
<!-- For proposed features, make sure there's an issue it's discussed first -->
