### PR TITLE
disable the completion command

### DIFF
--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -67,6 +67,9 @@ You can invoke krew through kubectl: "kubectl krew [command]..."`,
 	SilenceErrors:     true,
 	PersistentPreRunE: preRun,
 	PersistentPostRun: showUpgradeNotification,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Related issue: #769

/assign @ahmetb 

```
$ ./out/bin/krew-darwin_amd64
krew is the kubectl plugin manager.
You can invoke krew through kubectl: "kubectl krew [command]..."

Usage:
  kubectl krew [command]

Available Commands:
  help        Help about any command
  index       Manage custom plugin indexes
  info        Show information about an available plugin
  install     Install kubectl plugins
  list        List installed kubectl plugins
  search      Discover kubectl plugins
  uninstall   Uninstall plugins
  update      Update the local copy of the plugin index
  upgrade     Upgrade installed plugins to newer versions
  version     Show krew version and diagnostics

Flags:
  -h, --help      help for krew
  -v, --v Level   number for the log level verbosity

Use "kubectl krew [command] --help" for more information about a command.
```