### PR TITLE
Mention `KREW_ROOT` on instruction

### DIFF
--- a/cmd/krew/cmd/internal/setup_check.go
+++ b/cmd/krew/cmd/internal/setup_check.go
@@ -36,16 +36,16 @@ the following to your %s
 and restart your shell.`
 	instructionZsh = `~/.zshrc:
 
-    export PATH="${PATH}:${HOME}/.krew/bin"`
+    export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"`
 	instructionBash = `~/.bash_profile or ~/.bashrc:
 
-    export PATH="${PATH}:${HOME}/.krew/bin"`
+    export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"`
 	instructionFish = `config.fish:
 
-    set -gx PATH $PATH $HOME/.krew/bin`
+    set -q KREW_ROOT; and set -gx PATH $PATH $KREW_ROOT/.krew/bin; or set -gx PATH $PATH $HOME/.krew/bin`
 	instructionGeneric = `~/.bash_profile, ~/.bashrc, or ~/.zshrc:
 
-    export PATH="${PATH}:${HOME}/.krew/bin"`
+    export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"`
 )
 
 func IsBinDirInPATH(paths environment.Paths) bool {


### PR DESCRIPTION
Related issue: #767
The instruction on https://github.com/kubernetes-sigs/krew/blob/93827db2b9954e356456f24cc030419a899e95b1/hack/krew.yaml#L13-L16 mentions `KREW_ROOT` but one on cmd/krew/cmd/internal/setup_check.go doesn't.
This tweaks that instruction to mention `KREW_ROOT` there too.
The fish command is a bit long as there's no simple alternative to the unset variables on fish AFAIK.
