### PR TITLE
CI: Update some actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
 
     - name: Set up Go ${{ matrix.goVer }}
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.goVer }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: go mod download


### PR DESCRIPTION
Both now have v3, setup-go has a breaking change but there's no effect to us: https://github.com/actions/setup-go/releases/tag/v3.0.0
checkout has an internal change and it also shouldn't affect us.