### PR TITLE
Resolve inconsistency on long explanations

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -89,7 +89,7 @@ Install them at your own risk.
 var indexDeleteCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove a configured index",
-	Long: `Removes a configured plugin index
+	Long: `Remove a configured plugin index.
 
 It is only safe to remove indexes without installed plugins. Removing an index
 while there are plugins installed will result in an error, unless the --force


### PR DESCRIPTION
Other long explanations are like "Do ~~~." style but the index delete command is "Does ~~~". This resolves that inconsistency.