### PR TITLE
Fix tests for users that set KREW_ROOT

### DIFF
--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -26,9 +26,15 @@ import (
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
+func setKrewRootEnv(t *testing.T, value string) {
+	t.Helper()
+	oldKrewRoot := os.Getenv("KREW_ROOT")
+	os.Setenv("KREW_ROOT", value)
+	t.Cleanup(func() { os.Setenv("KREW_ROOT", oldKrewRoot) })
+}
+
 func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
-	// reset KREW_ROOT to ensure the default location
-	os.Unsetenv("KREW_ROOT")
+	setKrewRootEnv(t, "")
 	home := homedir.HomeDir()
 	expectedBase := filepath.Join(home, ".krew")
 	p := MustGetKrewPaths()
@@ -39,7 +45,7 @@ func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
 
 func TestMustGetKrewPaths_envOverride(t *testing.T) {
 	custom := filepath.FromSlash("/custom/krew/path")
-	t.Setenv("KREW_ROOT", custom)
+	setKrewRootEnv(t, custom)
 
 	p := MustGetKrewPaths()
 	if expected, got := custom, p.BasePath(); got != expected {

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
+	// reset KREW_ROOT to ensure the default location
+	os.Unsetenv("KREW_ROOT")
 	home := homedir.HomeDir()
 	expectedBase := filepath.Join(home, ".krew")
 	p := MustGetKrewPaths()

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -26,15 +26,8 @@ import (
 	"sigs.k8s.io/krew/pkg/constants"
 )
 
-func setKrewRootEnv(t *testing.T, value string) {
-	t.Helper()
-	oldKrewRoot := os.Getenv("KREW_ROOT")
-	os.Setenv("KREW_ROOT", value)
-	t.Cleanup(func() { os.Setenv("KREW_ROOT", oldKrewRoot) })
-}
-
 func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
-	setKrewRootEnv(t, "")
+	t.Setenv("KREW_ROOT", "")
 	home := homedir.HomeDir()
 	expectedBase := filepath.Join(home, ".krew")
 	p := MustGetKrewPaths()
@@ -45,7 +38,7 @@ func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
 
 func TestMustGetKrewPaths_envOverride(t *testing.T) {
 	custom := filepath.FromSlash("/custom/krew/path")
-	setKrewRootEnv(t, custom)
+	t.Setenv("KREW_ROOT", custom)
 
 	p := MustGetKrewPaths()
 	if expected, got := custom, p.BasePath(); got != expected {


### PR DESCRIPTION
I've noticed that updating the [krew AUR package](https://aur.archlinux.org/packages/krew) failed and after looking into
it I saw that the tests failed because I had set `KREW_ROOT`.
This patch unsets `KREW_ROOT` for the test case that asserts the default path.
