### PR TITLE
Update the installation URL of golangci-lint

### DIFF
--- a/hack/run-lint.sh
+++ b/hack/run-lint.sh
@@ -23,7 +23,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
   echo >&2 'Installing golangci-lint'
   curl --silent --fail --location \
-    https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$gopath/bin" v1.44.0
+    https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.44.0
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
Installation via https://install.goreleaser.com has been [deprecated](https://github.com/goreleaser/godownloader/issues/207) and now the server is unavailable, this replaces it with a recommend way stated on https://golangci-lint.run/usage/install/.
This will fix the CI issue e.g. https://github.com/kubernetes-sigs/krew/actions/runs/2384314784