### PR TITLE
Bump-up go version to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goVer: [1.17]
+        goVer: [1.18]
     steps:
 
     - name: Set up Go ${{ matrix.goVer }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/krew
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fatih/color v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -454,7 +454,6 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,22 +1,22 @@
 [build]
-GO_VERSION = "1.17"
+GO_VERSION = "1.18"
 base = "site/"
 publish = "public/"
 command = "hugo && cd ./functions && go build -o api ./server"
 functions = "functions/"
 
 [build.environment]
-GO_VERSION = "1.17"
+GO_VERSION = "1.18"
 HUGO_VERSION = "0.92.2"
 
 [context.production.environment]
-GO_VERSION = "1.17"
+GO_VERSION = "1.18"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-GO_VERSION = "1.17"
+GO_VERSION = "1.18"
 command = "hugo --buildFuture -b $DEPLOY_PRIME_URL && cd ./functions &&  go build -o api ./server"
 
 [context.branch-deploy]
-GO_VERSION = "1.17"
+GO_VERSION = "1.18"
 command = "hugo --buildFuture -b $DEPLOY_PRIME_URL && cd ./functions && go build -o api ./server"

--- a/site/functions/go.mod
+++ b/site/functions/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/krew/site/functions
 
-go 1.17
+go 1.18
 
 require (
 	github.com/apex/gateway v1.1.1


### PR DESCRIPTION
Bumping up the go version to 1.18
