### PR TITLE
Update the number of kubectl plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Krew is the package manager for kubectl plugins.
 Krew is a tool that makes it easy to use [kubectl
 plugins](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/). Krew
 helps you discover plugins, install and manage them on your machine. It is
-similar to tools like apt, dnf or [brew](https://brew.sh). Today, over [130
+similar to tools like apt, dnf or [brew](https://brew.sh). Today, over [200
 kubectl plugins][list] are available on Krew.
 
 - **For kubectl users:** Krew helps you find, install and manage kubectl plugins


### PR DESCRIPTION
To make it consistent with the number on website homepage: https://krew.sigs.k8s.io/
