### PR TITLE
Document windows entrypoint limitation of .exe

### DIFF
--- a/site/content/docs/developer-guide/plugin-manifest.md
+++ b/site/content/docs/developer-guide/plugin-manifest.md
@@ -205,3 +205,6 @@ plugin name (specifically the `metadata.name` field).
 >
 > For example, if your plugin name is `view-logs` and your plugin binary is named
 > `run.sh`, Krew will create a symbolic link named `kubectl-view_logs` automatically.
+
+> **Note on Windows entrypoints:** Currently only `.exe` entrypoints are supported
+> on Windows, `.bat` and `.ps1` are not supported, refer to [this issue](https://github.com/kubernetes-sigs/krew/issues/131).


### PR DESCRIPTION
There has been an issue open for some time discussing Windows entrypoint support. The proposal since early 2022 is that we just document that only `.exe` entrypoints on Windows are supported as anything else is an edge case. There has been no objection since, so lets update docs and close the issue.

Fixes #131

/kind cleanup
/area docs