### PR TITLE
Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/hack/ensure-kubectl-installed.sh
+++ b/hack/ensure-kubectl-installed.sh
@@ -27,7 +27,7 @@ install_kubectl_if_needed() {
     local goos goarch kubectl_url
     goos="$(go env GOOS)"
     goarch="$(go env GOARCH)"
-    kubectl_url="https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/${goos}/${goarch}/kubectl"
+    kubectl_url="https://dl.k8s.io/release/${kubectl_version}/bin/${goos}/${goarch}/kubectl"
 
     echo >&2 "kubectl not detected in environment, downloading ${kubectl_url}"
     mkdir -p "${bin_dir}"

--- a/hack/sandboxed.Dockerfile
+++ b/hack/sandboxed.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -qqy # retain the apt cache
 RUN apt-get install -qqy git curl wget
 
 ARG KUBECTL_VERSION=v1.14.2
-RUN curl -fsSLo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl  && \
+RUN curl -fsSLo /usr/bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl  && \
     chmod +x /usr/bin/kubectl
 
 # initialize index ahead of time


### PR DESCRIPTION
The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

Related PRs:

- https://github.com/kubernetes-sigs/image-builder/pull/656
- https://github.com/kubernetes-sigs/cluster-api/pull/4958
