### PR TITLE
Add using alternative branch support for custom indexes

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -64,9 +64,13 @@ each configured index in table format.`,
 }
 
 var indexAddCmd = &cobra.Command{
-	Use:     "add",
-	Short:   "Add a new index",
-	Long:    "Configure a new index to install plugins from.",
+	Use:   "add",
+	Short: "Add a new index",
+	Long: `Configure a new index to install plugins from.
+
+This command also supports alternative branch other than the default one
+by appending the branch name to the end of git url with # symbol
+(e.g. /kubernetes-sigs/krew-index.git#another_branch).`,
 	Example: "kubectl krew index add default " + constants.DefaultIndexURI,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(_ *cobra.Command, args []string) error {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -31,7 +31,12 @@ func EnsureCloned(uri, destinationPath string) error {
 	if ok, err := IsGitCloned(destinationPath); err != nil {
 		return err
 	} else if !ok {
-		_, err = Exec("", "clone", "-v", uri, destinationPath)
+		parsedURI := strings.Split(uri, "#")
+		if len(parsedURI) > 1 {
+			_, err = Exec("", "clone", "-v", "--single-branch", "--branch", parsedURI[1], parsedURI[0], destinationPath)
+		} else {
+			_, err = Exec("", "clone", "-v", uri, destinationPath)
+		}
 		return err
 	}
 	return nil

--- a/internal/index/indexoperations/index_test.go
+++ b/internal/index/indexoperations/index_test.go
@@ -102,6 +102,21 @@ func TestAddIndexFailure(t *testing.T) {
 	}
 }
 
+func TestAddIndexFailureWithCustomBranch(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t)
+
+	indexName := "foo"
+	localRepo := tmpDir.Path("local/" + indexName)
+	tmpDir.InitEmptyGitRepo(localRepo, "")
+
+	paths := environment.NewPaths(tmpDir.Root())
+
+	localRepoWithBranch := localRepo + "#test_branch"
+	if err := AddIndex(paths, indexName, localRepoWithBranch); err == nil {
+		t.Errorf("expected error test_branch not found")
+	}
+}
+
 func TestDeleteIndex(t *testing.T) {
 	// root directory does not exist
 	if err := DeleteIndex(environment.NewPaths(filepath.FromSlash("/tmp/does-not-exist/foo")), "bar"); err == nil {


### PR DESCRIPTION
Currently, when user adds a custom index, Krew clones this repository from the default branch statically. Since distributions of most of plugins are
managed in these default branches(master, main, etc.), it works without problem.

On the other hand, this mechanism does not work for the plugins that using branching strategy per release. For a specific cluster version, plugin maintainers want to force users to use only specific major version(and auto updates of minor versions via Krew). For example, for my cluster v1.2.X, user should use 1.2.X which means that user should add Krew custom index only being encompassed by this branch and I'll continue working on master branch for the next release cycle, v2.0.X. without impacting v1.2.X releases.

This PR proposes alternative branching support by appending branch name with `#` symbol. Since we are setting this branch name as default during clone phase, the rest of the functionality will remain same. If user wants to use different branch name for the same git uri, user should remove index first and re-add it with the name branch name.

Related issue: https://github.com/kubernetes-sigs/krew/issues/832
