### PR TITLE
clone single branch with depth of 1

### DIFF
--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -31,7 +31,7 @@ func EnsureCloned(uri, destinationPath string) error {
 	if ok, err := IsGitCloned(destinationPath); err != nil {
 		return err
 	} else if !ok {
-		_, err = Exec("", "clone", "-v", uri, destinationPath)
+		_, err = Exec("", "clone", "--depth=1", "--single-branch", "-v", uri, destinationPath)
 		return err
 	}
 	return nil


### PR DESCRIPTION
cloning only the default branch and with a depth of 1 speeds up the clone time greatly

```sh
I0818 19:01:24.786890   27900 git.go:79] Going to run git clone --depth=1 --single-branch -v git@gitlab.com:test/test.git /Users/dbrian/.krew/index/test
Cloning into '/Users/dbrian/.krew/index/test'...
I0818 19:01:25.342370   27900 fetch_tag.go:47] Parsing response from GitHub
```

```sh
I0818 19:00:39.064036   27722 git.go:79] Going to run git clone -v git@gitlab.com:test/test.git /Users/dbrian/.krew/index/test
Cloning into '/Users/dbrian/.krew/index/test'...
I0818 19:00:48.527775   27722 root.go:180] Upgrade check was skipped or has not finished
```

Fixes #403
<!-- For proposed features, make sure there's an issue it's discussed first -->
