### PR TITLE
add aliases to a few commands

### DIFF
--- a/cmd/krew/cmd/index.go
+++ b/cmd/krew/cmd/index.go
@@ -48,7 +48,8 @@ var indexListCmd = &cobra.Command{
 
 This command prints a list of indexes. It shows the name and the remote URL for
 each configured index in table format.`,
-	Args: cobra.NoArgs,
+	Aliases: []string{"ls"},
+	Args:    cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		indexes, err := indexoperations.ListIndexes(paths)
 		if err != nil {
@@ -95,8 +96,9 @@ It is only safe to remove indexes without installed plugins. Removing an index
 while there are plugins installed will result in an error, unless the --force
 option is used (not recommended).`,
 
-	Args: cobra.ExactArgs(1),
-	RunE: indexDelete,
+	Aliases: []string{"rm"},
+	Args:    cobra.ExactArgs(1),
+	RunE:    indexDelete,
 }
 
 func indexDelete(_ *cobra.Command, args []string) error {

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -39,6 +39,7 @@ Remarks:
   Redirecting the output of this command to a program or file will only print
   the names of the plugins installed. This output can be piped back to the
   "install" command.`,
+		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			receipts, err := installation.GetInstalledPluginReceipts(paths.InstallReceiptsPath())
 			if err != nil {

--- a/cmd/krew/cmd/uninstall.go
+++ b/cmd/krew/cmd/uninstall.go
@@ -54,7 +54,7 @@ Remarks:
 	},
 	PreRunE: checkIndex,
 	Args:    cobra.MinimumNArgs(1),
-	Aliases: []string{"remove"},
+	Aliases: []string{"remove", "rm"},
 }
 
 func unsafePluginNameErr(n string) error { return errors.Errorf("plugin name %q not allowed", n) }


### PR DESCRIPTION
these are some aliases that homebrew has that i thought would be nice to include here as well (not that krew needs to mimic homebrew in every way, but still a minor convenience i think). the `ls` one isnt really a big deal but i think having `rm` as an option instead of `uninstall` or `remove` is nice. if theres a reason we dont want to include these though then its not a big deal. ive never heard of any complaints about this so its purely a "nice to have" in my mind.

/assign @ahmetb 