### PR TITLE
fix: chmod 0755 store/PLUGIN/VER dir

### DIFF
--- a/internal/installation/move.go
+++ b/internal/installation/move.go
@@ -161,7 +161,12 @@ func moveToInstallDir(srcDir, installDir string, fos []index.FileOperation) erro
 	tmp, err := os.MkdirTemp("", "krew-temp-move")
 	klog.V(4).Infof("Creating temp plugin move operations dir %q", tmp)
 	if err != nil {
-		return errors.Wrap(err, "failed to find a temporary director")
+		return errors.Wrap(err, "failed to find a temporary directory")
+	}
+	klog.V(4).Infof("Chmoding tmpdir to 0755", tmp)
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		// mktemp gives a 0700 directory but since we move this to KREW_ROOT, we need to make it 0755
+		return errors.Wrap(err, "failed to chmod temp directory")
 	}
 	defer os.RemoveAll(tmp)
 


### PR DESCRIPTION
Because we're doing `mktemp` (which gives 0700) and then moving it to `$KREW_ROOT/store/PLUGIN/VERSION`, we need to make sure that the directory is 0755 like the other dirs in `store`.

See #840.
