### PR TITLE
docs: updated the link of the plugin stats dashboard

### DIFF
--- a/site/content/docs/developer-guide/plugin-stats.md
+++ b/site/content/docs/developer-guide/plugin-stats.md
@@ -12,9 +12,8 @@ time.
 
 To see your plugin’s download statistics over time:
 
-1. Visit the [stats.krew.dev] dashboard.
-2. Click the “Individual Plugin Stats” report.
-3. Choose your plugin from the dropdown and browse the data for your plugin.
+1. Visit the [krew-index-tracker] dashboard.
+2. Choose your plugin from the dropdown and browse the data for your plugin.
 
 This data is obtained by scraping the downloads count of your plugin assets via
 the [GitHub API] regularly. Since Krew does not track its users, this data:
@@ -28,8 +27,8 @@ the [GitHub API] regularly. Since Krew does not track its users, this data:
 > its availability and accuracy.
 >
 > The scraping code can be found
-> [here](https://github.com/corneliusweig/krew-index-tracker).
+> [here](https://github.com/predatorray/krew-index-tracker).
 
 [GitHub releases]: https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository
-[stats.krew.dev]: https://datastudio.google.com/c/reporting/f74370a0-adcf-4cec-b7bd-a58c638948f5/page/Ufl7
+[krew-index-tracker]: https://predatorray.github.io/krew-index-tracker/
 [GitHub API]: https://developer.github.com/v3/repos/releases/#list-assets-for-a-release


### PR DESCRIPTION
Related issue: #845

Hi there,

As discussed in the issue #845 previously, I am updating the link on the "Plugin usage analytics" page, which will point to the new [dashboard](https://predatorray.github.io/krew-index-tracker/). The source code is available at: [predatorray/krew-index-tracker](https://github.com/predatorray/krew-index-tracker).

And also, since I don't know how "stats.krew.dev" is configured to make redirection to the Google's Dashboard, I just use the Github Page link here. Please let me know if we can also update the redirection as the same time.

Thanks!