### PR TITLE
bump golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,61 +1,67 @@
-# all available settings of specific linters
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - performance
-      - diagnostic
-      - style
-      - experimental
-      - opinionated
-    disabled-checks:
-      - hugeParam
-      - rangeValCopy
-      - unnamedResult
-  gofmt:
-    simplify: true
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: sigs.k8s.io/krew
-  errcheck:
-    check-type-assertions: false
-    check-blank: false
-  staticcheck:
-    checks:
-    - all
-    - "-SA1019" # allow usage of global rand.Seed
-
-
-# options for analysis running
+version: "2"
 run:
-  # include test files
   tests: true
-
-issues:
-  # which dirs to skip: they won't be analyzed;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but next dirs are always skipped independently
-  # from this option's value:
-  #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  exclude-dirs:
-    - hack
-    - docs
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - gocritic
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
     - unconvert
     - unparam
     - unused
+  settings:
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    gocritic:
+      disabled-checks:
+        - hugeParam
+        - rangeValCopy
+        - unnamedResult
+      enabled-tags:
+        - performance
+        - diagnostic
+        - style
+        - experimental
+        - opinionated
+    staticcheck:
+      checks:
+        - all
+        - -SA1019
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - hack
+      - docs
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - sigs.k8s.io/krew
+  exclusions:
+    generated: lax
+    paths:
+      - hack
+      - docs
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/receiptsmigration/migration.go
+++ b/internal/receiptsmigration/migration.go
@@ -36,5 +36,5 @@ func Done(newPaths environment.Paths) (bool, error) {
 	hasInstalledPlugins := len(plugins) > 0
 	hasNoReceipts := len(receipts) == 0
 
-	return !(hasInstalledPlugins && hasNoReceipts), nil
+	return !(hasInstalledPlugins && hasNoReceipts), nil //nolint:staticcheck
 }

--- a/internal/testutil/plugin.go
+++ b/internal/testutil/plugin.go
@@ -57,7 +57,7 @@ func NewPlugin() *P {
 	}}
 }
 
-func (p *P) WithName(s string) *P                 { p.v.ObjectMeta.Name = s; return p }
+func (p *P) WithName(s string) *P                 { p.v.Name = s; return p }
 func (p *P) WithShortDescription(v string) *P     { p.v.Spec.ShortDescription = v; return p }
 func (p *P) WithTypeMeta(v metav1.TypeMeta) *P    { p.v.TypeMeta = v; return p }
 func (p *P) WithPlatforms(v ...index.Platform) *P { p.v.Spec.Platforms = v; return p }


### PR DESCRIPTION
Updates golangci-lint to v2 utilizing the `golangci-lint migrate` command from the v2 cli. Also addresses associated lints from updates to linters.

Fixes #879


