### PR TITLE
Use relative symlinks for plugin binaries

### DIFF
--- a/internal/installation/install.go
+++ b/internal/installation/install.go
@@ -197,10 +197,16 @@ func createOrUpdateLink(binDir, binary, plugin string) error {
 		return errors.Wrapf(err, "can't create symbolic link, source binary (%q) cannot be found in extracted archive", binary)
 	}
 
-	// Create new
-	klog.V(2).Infof("Creating symlink to %q at %q", binary, dst)
-	if err := os.Symlink(binary, dst); err != nil {
-		return errors.Wrapf(err, "failed to create a symlink from %q to %q", binary, dst)
+	// Compute relative path from binDir to binary for portable symlinks
+	relPath, err := filepath.Rel(binDir, binary)
+	if err != nil {
+		return errors.Wrap(err, "failed to compute relative path for symlink")
+	}
+
+	// Create new symlink with relative path
+	klog.V(2).Infof("Creating relative symlink to %q at %q", relPath, dst)
+	if err := os.Symlink(relPath, dst); err != nil {
+		return errors.Wrapf(err, "failed to create a symlink from %q to %q", relPath, dst)
 	}
 	klog.V(2).Infof("Created symlink at %q", dst)
 


### PR DESCRIPTION
Use relative symlinks for plugin binaries

Fixes #822
Related issue: #815

## Migration Path

- New plugin installations immediately create relative symlinks
- Existing absolute symlinks are automatically converted to relative when plugins are upgraded
- Both absolute and relative symlinks are supported during the transition
- No user action required - migration happens transparently

## Testing

Verified portability after moving `KREW_ROOT`:

```bash
# Build and install plugin
KREW_ROOT=$PWD/.krew-test ./krew install krew

# Verify symlink is relative
$ readlink .krew-test/bin/kubectl-krew
../store/krew/v0.4.5/krew  # ✅ Relative path

# Move KREW_ROOT
mv .krew-test .krew-moved

# Verify plugin still works
$ KREW_ROOT=$PWD/.krew-moved .krew-moved/bin/kubectl-krew version
GitTag            v0.4.5  # ✅ Works after move
BasePath          .../krew/.krew-moved  # ✅ Correct new path
```

Related issue #815 discusses XDG Base Directory support. This PR addresses the symlink portability blocker mentioned in that discussion.