### PR TITLE
fix: upgrade Go to 1.26.0 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/krew
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.26.0 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

This is a minimal version bump fix.