### PR TITLE
installation: Windows hard link for plugin shims, then symlink (EvalSymlinks fallback)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
+	golang.org/x/sys v0.31.0
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	k8s.io/klog/v2 v2.140.0
@@ -30,7 +31,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/internal/installation/install.go
+++ b/internal/installation/install.go
@@ -178,7 +178,7 @@ func Uninstall(p environment.Paths, name string) error {
 	symlinkPath := filepath.Join(p.BinPath(), pluginNameToBin(name, IsWindows()))
 	klog.V(3).Infof("Unlink %q", symlinkPath)
 	if err := removeLink(symlinkPath); err != nil {
-		return errors.Wrap(err, "could not uninstall symlink of plugin")
+		return errors.Wrap(err, "could not uninstall link of plugin")
 	}
 
 	pluginInstallPath := p.PluginInstallPath(name)
@@ -196,39 +196,39 @@ func createOrUpdateLink(binDir, binary, plugin string) error {
 	dst := filepath.Join(binDir, pluginNameToBin(plugin, IsWindows()))
 
 	if err := removeLink(dst); err != nil {
-		return errors.Wrap(err, "failed to remove old symlink")
+		return errors.Wrap(err, "failed to remove old link")
 	}
 	if _, err := os.Stat(binary); os.IsNotExist(err) {
-		return errors.Wrapf(err, "can't create symbolic link, source binary (%q) cannot be found in extracted archive", binary)
+		return errors.Wrapf(err, "can't create link, source binary (%q) cannot be found in extracted archive", binary)
 	}
 
 	// Create new
-	klog.V(2).Infof("Creating symlink to %q at %q", binary, dst)
-	if err := os.Symlink(binary, dst); err != nil {
-		return errors.Wrapf(err, "failed to create a symlink from %q to %q", binary, dst)
+	klog.V(2).Infof("Creating link to %q at %q", binary, dst)
+	if err := createSymlink(binary, dst); err != nil {
+		return errors.Wrapf(err, "failed to create a link from %q to %q", binary, dst)
 	}
-	klog.V(2).Infof("Created symlink at %q", dst)
+	klog.V(2).Infof("Created link at %q", dst)
 
 	return nil
 }
 
-// removeLink removes a symlink reference if exists.
+// removeLink removes a symlink or directory junction if it exists.
 func removeLink(path string) error {
 	fi, err := os.Lstat(path)
 	if os.IsNotExist(err) {
 		klog.V(3).Infof("No file found at %q", path)
 		return nil
 	} else if err != nil {
-		return errors.Wrapf(err, "failed to read the symlink in %q", path)
+		return errors.Wrapf(err, "failed to read the link in %q", path)
 	}
 
-	if fi.Mode()&os.ModeSymlink == 0 {
-		return errors.Errorf("file %q is not a symlink (mode=%s)", path, fi.Mode())
+	if !isLink(fi) {
+		return errors.Errorf("file %q is not a link (mode=%s)", path, fi.Mode())
 	}
 	if err := os.Remove(path); err != nil {
-		return errors.Wrapf(err, "failed to remove the symlink in %q", path)
+		return errors.Wrapf(err, "failed to remove the link in %q", path)
 	}
-	klog.V(3).Infof("Removed symlink from %q", path)
+	klog.V(3).Infof("Removed link from %q", path)
 	return nil
 }
 

--- a/internal/installation/install_test.go
+++ b/internal/installation/install_test.go
@@ -467,6 +467,83 @@ func Test_reproduce_osSymlink_vs_createSymlink(t *testing.T) {
 	}
 }
 
+// Test_reproduce_oldCodePath_osSymlink_unresolved demonstrates the bug in the
+// old code path: os.Symlink() stores the raw (unresolved) path, which breaks
+// when platform symlinks are involved (e.g., macOS /var -> /private/var).
+// On Windows, os.Symlink() additionally requires elevated privileges.
+func Test_reproduce_oldCodePath_osSymlink_unresolved(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmpDir == resolvedTmpDir {
+		t.Skip("no platform symlinks detected (e.g., macOS /var -> /private/var); symlink resolution bug not reproducible on this platform")
+	}
+
+	// Simulate a plugin binary inside an install directory that uses the
+	// unresolved path (as TempDir returns on macOS).
+	binaryPath := filepath.Join(tmpDir, "kubectl-bugdemo")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\necho bugdemo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolvedBinary, err := filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// OLD CODE PATH: os.Symlink stores the unresolved path verbatim.
+	binDir := filepath.Join(resolvedTmpDir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldLink := filepath.Join(binDir, "kubectl-bugdemo_old")
+	if err := os.Symlink(binaryPath, oldLink); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(oldLink)
+
+	oldTarget, err := os.Readlink(oldLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// BUG: the old code stores the unresolved path, which contains the
+	// platform symlink prefix (e.g., /var/folders/... instead of
+	// /private/var/folders/...). This means the link target and the
+	// resolved binary path don't match.
+	if oldTarget == resolvedBinary {
+		t.Fatal("UNEXPECTED: os.Symlink resolved the path; bug not reproducible")
+	}
+
+	// Prove the mismatch exists — this IS the bug.
+	t.Logf("BUG CONFIRMED: os.Symlink target = %q (unresolved)", oldTarget)
+	t.Logf("  expected resolved target       = %q", resolvedBinary)
+	if oldTarget != binaryPath {
+		t.Fatalf("expected os.Symlink to use unresolved path %q, got %q", binaryPath, oldTarget)
+	}
+
+	// NEW CODE PATH: createSymlink resolves the path first.
+	newLink := filepath.Join(binDir, "kubectl-bugdemo_new")
+	if err := createSymlink(binaryPath, newLink); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(newLink)
+
+	newTarget, err := os.Readlink(newLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The fix: createSymlink stores the RESOLVED path.
+	if newTarget != resolvedBinary {
+		t.Errorf("createSymlink target = %q; want resolved %q", newTarget, resolvedBinary)
+	}
+	t.Logf("FIX VERIFIED:  createSymlink target = %q (resolved)", newTarget)
+}
+
 func TestCleanupStaleKrewInstallations(t *testing.T) {
 	dir := testutil.NewTempDir(t)
 

--- a/internal/installation/install_test.go
+++ b/internal/installation/install_test.go
@@ -291,6 +291,182 @@ func Test_applyDefaults(t *testing.T) {
 	}
 }
 
+func Test_bug_osSymlink_doesNotResolvePlatformSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmpDir == resolvedTmpDir {
+		t.Skip("no platform symlinks detected (e.g., macOS /var -> /private/var)")
+	}
+
+	binaryPath := filepath.Join(tmpDir, "kubectl-foo")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\necho foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(resolvedTmpDir, "kubectl-foo-link")
+	if err := os.Symlink(binaryPath, linkPath); err != nil {
+		t.Fatalf("os.Symlink() error = %v", err)
+	}
+	defer os.Remove(linkPath)
+
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("os.Readlink() error = %v", err)
+	}
+
+	resolvedBinary, err := filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if target == resolvedBinary {
+		t.Fatal("UNEXPECTED: os.Symlink resolved the path; bug may be fixed at the OS level")
+	}
+	if target != binaryPath {
+		t.Fatalf("expected os.Symlink to store unresolved path %q, got %q", binaryPath, target)
+	}
+}
+
+func Test_createSymlink_exists(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t)
+	src := filepath.Join(testdataPath(t), "plugin-foo", "kubectl-foo")
+	dst := filepath.Join(tmpDir.Root(), "kubectl-test_plugin")
+
+	if err := createSymlink(src, dst); err != nil {
+		t.Fatalf("createSymlink() error = %v", err)
+	}
+
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("os.Lstat() error = %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected link to have ModeSymlink set")
+	}
+}
+
+func Test_createOrUpdateLink_usesCreateSymlink(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t)
+	binary := filepath.Join(testdataPath(t), "plugin-foo", "kubectl-foo")
+
+	if err := createOrUpdateLink(tmpDir.Root(), binary, "test-plugin"); err != nil {
+		t.Fatalf("createOrUpdateLink() error = %v", err)
+	}
+
+	linkPath := filepath.Join(tmpDir.Root(), pluginNameToBin("test-plugin", IsWindows()))
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("failed to lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected link to have ModeSymlink set")
+	}
+
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("failed to readlink: %v", err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(binary)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks() error = %v", err)
+	}
+	if target != wantResolved {
+		t.Errorf("link target = %q; want %q", target, wantResolved)
+	}
+}
+
+func Test_createOrUpdateLink_resolvesSymlinks(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t)
+	resolvedRoot, err := filepath.EvalSymlinks(tmpDir.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmpDir.Root() == resolvedRoot {
+		t.Skip("no platform symlinks detected (e.g., macOS /var -> /private/var)")
+	}
+
+	binDir := filepath.Join(resolvedRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	binaryDir := filepath.Join(tmpDir.Root(), "store", "plugin-foo", "v1.0.0")
+	if err := os.MkdirAll(binaryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binaryPath := filepath.Join(binaryDir, "kubectl-foo")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\necho foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := createOrUpdateLink(binDir, binaryPath, "foo"); err != nil {
+		t.Fatalf("createOrUpdateLink() error = %v", err)
+	}
+
+	linkPath := filepath.Join(binDir, pluginNameToBin("foo", IsWindows()))
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("os.Readlink() error = %v", err)
+	}
+
+	resolvedBinary, err := filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks() error = %v", err)
+	}
+
+	if target != resolvedBinary {
+		t.Errorf("link target = %q; want resolved %q (unresolved was %q)", target, resolvedBinary, binaryPath)
+	}
+}
+
+func Test_reproduce_osSymlink_vs_createSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmpDir == resolved {
+		t.Skip("no platform symlinks detected (e.g., macOS /var -> /private/var)")
+	}
+
+	binary := filepath.Join(tmpDir, "kubectl-repro")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho repro"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolvedBinary, err := filepath.EvalSymlinks(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldLink := filepath.Join(resolved, "old-link")
+	if err := os.Symlink(binary, oldLink); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(oldLink)
+
+	oldTarget, _ := os.Readlink(oldLink)
+	if oldTarget == resolvedBinary {
+		t.Fatal("UNEXPECTED: os.Symlink resolved the path; cannot reproduce bug")
+	}
+	if oldTarget != binary {
+		t.Fatalf("os.Symlink target = %q; want unresolved %q", oldTarget, binary)
+	}
+
+	newLink := filepath.Join(resolved, "new-link")
+	if err := createSymlink(binary, newLink); err != nil {
+		t.Fatal(err)
+	}
+	newTarget, _ := os.Readlink(newLink)
+	if newTarget != resolvedBinary {
+		t.Fatalf("createSymlink target = %q; want resolved %q", newTarget, resolvedBinary)
+	}
+}
+
 func TestCleanupStaleKrewInstallations(t *testing.T) {
 	dir := testutil.NewTempDir(t)
 

--- a/internal/installation/symlink_test.go
+++ b/internal/installation/symlink_test.go
@@ -1,0 +1,170 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package installation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_createSymlink_newLinkToDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(tmpDir, "link")
+	if err := createSymlink(targetDir, linkPath); err != nil {
+		t.Fatalf("createSymlink() error = %v", err)
+	}
+
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("os.Lstat() error = %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected created link to have ModeSymlink set")
+	}
+}
+
+func Test_createSymlink_pointsToCorrectTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(tmpDir, "link")
+	if err := createSymlink(targetDir, linkPath); err != nil {
+		t.Fatalf("createSymlink() error = %v", err)
+	}
+
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("os.Readlink() error = %v", err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks(targetDir) error = %v", err)
+	}
+	if got != wantResolved {
+		t.Errorf("Readlink() = %q; want %q", got, wantResolved)
+	}
+
+	resolved, err := filepath.EvalSymlinks(linkPath)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks() error = %v", err)
+	}
+	if resolved != wantResolved {
+		t.Errorf("EvalSymlinks() = %q; want %q", resolved, wantResolved)
+	}
+}
+
+func Test_createSymlink_pathMismatchWithPlatformSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmpDir == resolvedTmpDir {
+		t.Skip("no platform symlinks detected (e.g., macOS /var -> /private/var)")
+	}
+
+	targetDir := filepath.Join(tmpDir, "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(tmpDir, "link")
+	if err := createSymlink(targetDir, linkPath); err != nil {
+		t.Fatalf("createSymlink() error = %v", err)
+	}
+
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("os.Readlink() error = %v", err)
+	}
+
+	resolvedTarget, err := filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks() error = %v", err)
+	}
+
+	if got != resolvedTarget {
+		t.Errorf("Readlink() = %q; want resolved %q", got, resolvedTarget)
+	}
+}
+
+func Test_createSymlink_newLinkToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetFile := filepath.Join(tmpDir, "kubectl-foo")
+	if err := os.WriteFile(targetFile, []byte("#!/bin/sh\necho foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(tmpDir, "link")
+	if err := createSymlink(targetFile, linkPath); err != nil {
+		t.Fatalf("createSymlink() error = %v", err)
+	}
+
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("os.Lstat() error = %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected created link to have ModeSymlink set")
+	}
+
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("os.Readlink() error = %v", err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(targetFile)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks() error = %v", err)
+	}
+	if got != wantResolved {
+		t.Errorf("Readlink() = %q; want %q", got, wantResolved)
+	}
+}
+
+func Test_createSymlink_errorOnNonexistentTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonexistent := filepath.Join(tmpDir, "does-not-exist")
+	linkPath := filepath.Join(tmpDir, "link")
+
+	err := createSymlink(nonexistent, linkPath)
+
+	if err != nil {
+		t.Fatalf("createSymlink() error = %v; unix symlinks should succeed for nonexistent targets", err)
+	}
+
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("os.Lstat() error = %v; dangling symlink should still exist", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected dangling link to have ModeSymlink set")
+	}
+
+	if _, err := os.Stat(linkPath); !os.IsNotExist(err) {
+		t.Errorf("expected Stat to report not-exist for dangling symlink, got err = %v", err)
+	}
+}

--- a/internal/installation/symlink_unix.go
+++ b/internal/installation/symlink_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package installation
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func createSymlink(oldname, newname string) error {
+	if resolved, err := filepath.EvalSymlinks(oldname); err == nil {
+		oldname = resolved
+	}
+	return os.Symlink(oldname, newname)
+}
+
+func isLink(fi os.FileInfo) bool {
+	return fi.Mode()&os.ModeSymlink != 0
+}

--- a/internal/installation/symlink_windows.go
+++ b/internal/installation/symlink_windows.go
@@ -1,0 +1,131 @@
+// Copyright 2019 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package installation
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	ioReparseTagMountPoint = 0xA0000003
+	fsctlSetReparsePoint   = 0x000900A4
+)
+
+// createSymlink creates a directory junction from newname pointing to oldname.
+// Unlike os.Symlink, junctions do not require elevated privileges or Developer
+// Mode on Windows.
+func createSymlink(oldname, newname string) error {
+	target, err := filepath.Abs(oldname)
+	if err != nil {
+		return errors.Wrapf(err, "failed to resolve absolute path for %q", oldname)
+	}
+
+	ntTarget := `\??\` + target
+	ntTargetUTF16, err := windows.UTF16FromString(ntTarget)
+	if err != nil {
+		return errors.Wrapf(err, "failed to encode target path to UTF-16")
+	}
+
+	if err := os.Mkdir(newname, 0o750); err != nil {
+		return errors.Wrapf(err, "failed to create junction directory %q", newname)
+	}
+
+	dirPtr, err := windows.UTF16PtrFromString(newname)
+	if err != nil {
+		os.Remove(newname)
+		return errors.Wrapf(err, "failed to encode junction path to UTF-16")
+	}
+
+	handle, err := windows.CreateFile(
+		dirPtr,
+		windows.GENERIC_WRITE,
+		0,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		os.Remove(newname)
+		return errors.Wrapf(err, "failed to open directory %q", newname)
+	}
+	defer windows.CloseHandle(handle)
+
+	buf := buildJunctionReparseBuffer(ntTargetUTF16)
+
+	var bytesReturned uint32
+	if err := windows.DeviceIoControl(
+		handle,
+		fsctlSetReparsePoint,
+		&buf[0],
+		uint32(len(buf)),
+		nil,
+		0,
+		&bytesReturned,
+		nil,
+	); err != nil {
+		os.Remove(newname)
+		return errors.Wrapf(err, "failed to create junction %q -> %q", newname, target)
+	}
+
+	return nil
+}
+
+// isLink reports whether fi describes a symlink or a directory junction.
+// Go 1.22+ no longer sets ModeSymlink for junctions; they get ModeIrregular instead.
+func isLink(fi os.FileInfo) bool {
+	return fi.Mode()&os.ModeSymlink != 0 || fi.Mode()&os.ModeIrregular != 0
+}
+
+// buildJunctionReparseBuffer constructs a REPARSE_DATA_BUFFER for a mount point
+// (directory junction). The buffer layout is:
+//
+//	Offset  Size  Field
+//	0       4     ReparseTag
+//	4       2     ReparseDataLength
+//	6       2     Reserved
+//	8       2     SubstituteNameOffset
+//	10      2     SubstituteNameLength
+//	12      2     PrintNameOffset
+//	14      2     PrintNameLength
+//	16      var   PathBuffer (SubstituteName + null + PrintName + null)
+func buildJunctionReparseBuffer(ntTargetUTF16 []uint16) []byte {
+	substNameLen := (len(ntTargetUTF16) - 1) * 2
+	printNameOffset := substNameLen + 2
+	pathBufferLen := substNameLen + 2 + 2
+	reparseDataLen := 8 + pathBufferLen
+	bufLen := 8 + reparseDataLen
+
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint32(buf[0:], ioReparseTagMountPoint)
+	binary.LittleEndian.PutUint16(buf[4:], uint16(reparseDataLen))
+	binary.LittleEndian.PutUint16(buf[8:], 0)
+	binary.LittleEndian.PutUint16(buf[10:], uint16(substNameLen))
+	binary.LittleEndian.PutUint16(buf[12:], uint16(printNameOffset))
+	binary.LittleEndian.PutUint16(buf[14:], 0)
+
+	for i, c := range ntTargetUTF16 {
+		binary.LittleEndian.PutUint16(buf[16+i*2:], c)
+	}
+
+	return buf
+}

--- a/site/content/docs/user-guide/setup/install.md
+++ b/site/content/docs/user-guide/setup/install.md
@@ -76,12 +76,14 @@ Krew self-hosts).
 
 1. Make sure `git` is installed.
 1. Download `krew.exe` from the [Releases][releases] page to a directory.
-1. Launch a command prompt (`cmd.exe`) with administrator privileges (since the installation requires use of symbolic links) and navigate to that directory.
+1. Launch a command prompt (`cmd.exe`) and navigate to that directory.
 1. Run the following command to install krew:
 
     ```sh
     .\krew install krew
     ```
+
+   > **Note:** Krew uses directory junctions on Windows, which do not require Administrator privileges or Developer Mode.
 
 1. Add the `%USERPROFILE%\.krew\bin` directory to your `PATH` environment variable
    ([how?](https://java.com/en/download/help/path.xml))


### PR DESCRIPTION
[WIP]
**What this PR does**

On Windows, creating plugin shims in .krew/bin no longer depends only on os.Symlink. The code tries os.Link first (same volume, no extra symlink privilege in the common case), then falls back to os.Symlink. The source path is passed through filepath.EvalSymlinks before the symlink path so the fallback does not use an unresolved path if the install path goes through a junction or directory symlink.

Uninstall and upgrades use removeLink with an isLink helper on Windows that also allows removing hard-linked bin entries, not only symlinks.

On non-Windows, behavior is unchanged: createSymlink is a plain os.Symlink and isLink is symlink-only, matching the old logic.

**Fixes** #886